### PR TITLE
fix: look for more a specific error in checkBootstrapped

### DIFF
--- a/internal/juju/juju_test.go
+++ b/internal/juju/juju_test.go
@@ -26,9 +26,21 @@ func setupHandlerWithPreset(preset string) (*system.MockSystem, *JujuHandler, er
 	var provider providers.Provider
 
 	system := system.NewMockSystem()
-	system.MockCommandReturn("sudo -u test-user juju show-controller concierge-lxd", []byte("not found"), fmt.Errorf("Test error"))
-	system.MockCommandReturn("sudo -u test-user juju show-controller concierge-microk8s", []byte("not found"), fmt.Errorf("Test error"))
-	system.MockCommandReturn("sudo -u test-user juju show-controller concierge-k8s", []byte("not found"), fmt.Errorf("Test error"))
+	system.MockCommandReturn(
+		"sudo -u test-user juju show-controller concierge-lxd",
+		[]byte("ERROR controller concierge-lxd not found"),
+		fmt.Errorf("Test error"),
+	)
+	system.MockCommandReturn(
+		"sudo -u test-user juju show-controller concierge-microk8s",
+		[]byte("ERROR controller concierge-microk8s not found"),
+		fmt.Errorf("Test error"),
+	)
+	system.MockCommandReturn(
+		"sudo -u test-user juju show-controller concierge-k8s",
+		[]byte("ERROR controller concierge-k8s not found"),
+		fmt.Errorf("Test error"),
+	)
 
 	cfg, err = config.Preset(preset)
 	if err != nil {
@@ -68,6 +80,7 @@ func setupHandlerWithGoogleProvider() (*system.MockSystem, *JujuHandler, error) 
 	handler := NewJujuHandler(cfg, system, []providers.Provider{provider})
 	return system, handler, nil
 }
+
 func TestJujuHandlerCommandsPresets(t *testing.T) {
 	type test struct {
 		preset           string


### PR DESCRIPTION
Testing if the output contains just "not found" is too loose, as some intermittent errors include phrases like "pod not found", for example:

```
Command: /snap/bin/juju show-controller concierge-microk8s Output:
{}
ERROR opening API connection: starting proxy for api connection: \
    connecting k8s proxy: forwarding ports: error upgrading connection: \
    unable to upgrade connection: pod not found ("controller-0_controller-concierge-microk8s")
```
So look for the specific `controller <name> not found` error. This might be a bit *too* narrow, but at least it'll work.

This bug was causing concierge to think the controller wasn't there, and falling through to do the bootstrap, which then failed with "controller ... already exists" and kept retrying.

The PR branch is on my `benhoyt/concierge` fork, but I've also pushed these changes to `canonical/concierge` under the same branch name, so that you can test it using `go install`:

```
$ go install github.com/canonical/concierge@fix-not-found-handling
go: downloading github.com/canonical/concierge v1.0.3-0.20250613050548-f7a9a63cd62b
```

Fixes #64