### PR TITLE
chore: fix CVE-2025-22874

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/canonical/concierge
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.4
 
 require (
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b

--- a/internal/system/util.go
+++ b/internal/system/util.go
@@ -16,7 +16,7 @@ func generateTraceMessage(cmd string, output []byte) string {
 	green := color.New(color.FgGreen, color.Bold, color.Underline)
 	bold := color.New(color.Bold)
 
-	result := fmt.Sprintf("%s %s\n", green.Sprintf("Command:"), bold.Sprintf("%s", cmd))
+	result := fmt.Sprintf("%s %s\n", green.Sprint("Command:"), bold.Sprint(cmd))
 	if len(output) > 0 {
 		result = fmt.Sprintf("%s%s\n%s", result, green.Sprintf("Output:"), string(output))
 	}

--- a/internal/system/util.go
+++ b/internal/system/util.go
@@ -16,7 +16,7 @@ func generateTraceMessage(cmd string, output []byte) string {
 	green := color.New(color.FgGreen, color.Bold, color.Underline)
 	bold := color.New(color.Bold)
 
-	result := fmt.Sprintf("%s %s\n", green.Sprintf("Command:"), bold.Sprintf(cmd))
+	result := fmt.Sprintf("%s %s\n", green.Sprintf("Command:"), bold.Sprintf("%s", cmd))
 	if len(output) > 0 {
 		result = fmt.Sprintf("%s%s\n%s", result, green.Sprintf("Output:"), string(output))
 	}


### PR DESCRIPTION
Per [discussion on mattermost](https://chat.canonical.com/canonical/pl/4qmqkitr6pys5dgeji6tqz7i6w), we need to fix https://github.com/advisories/GHSA-6f52-wpx2-hvf2 by upgrading to Go 1.24.4.

Similar to the Pebble repo, `snyk test` scan doesn't find this CVE in this repo:

```bash
$ snyk test

Testing /Users/tiexin/work/concierge...

Organization:      ironcore864
Package manager:   gomodules
Target file:       go.mod
Project name:      github.com/canonical/concierge
Open source:       no
Project path:      /Users/tiexin/work/concierge
Licenses:          enabled

✔ Tested 104 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.
```

But to be on the safer side, we will grade to Go 1.24.4.