### PR TITLE
feat: explicitly set controller and model arch when bootstrapping

### DIFF
--- a/internal/juju/juju.go
+++ b/internal/juju/juju.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -204,6 +205,14 @@ func (j *JujuHandler) bootstrapProvider(provider providers.Provider) error {
 	// Combine the global and provider-local model-defaults and bootstrap-constraints.
 	modelDefaults := config.MergeMaps(j.modelDefaults, provider.ModelDefaults())
 	bootstrapConstraints := config.MergeMaps(j.bootstrapConstraints, provider.BootstrapConstraints())
+
+	// Explicitly set "arch" bootstrap constraint if not set by user.
+	if _, ok := bootstrapConstraints["arch"]; !ok {
+		bootstrapConstraints["arch"] = runtime.GOARCH
+	}
+
+	// Explicitly set "arch" model constraint.
+	bootstrapArgs = append(bootstrapArgs, "--constraints", "arch="+runtime.GOARCH)
 
 	// Iterate over the model-defaults and append them to the bootstrapArgs
 	for _, k := range sortedKeys(modelDefaults) {

--- a/internal/juju/juju_test.go
+++ b/internal/juju/juju_test.go
@@ -3,6 +3,7 @@ package juju
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/canonical/concierge/internal/config"
@@ -94,7 +95,7 @@ func TestJujuHandlerCommandsPresets(t *testing.T) {
 			expectedCommands: []string{
 				"snap install juju",
 				"sudo -u test-user juju show-controller concierge-lxd",
-				"sudo -u test-user -g lxd juju bootstrap localhost concierge-lxd --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true",
+				"sudo -u test-user -g lxd juju bootstrap localhost concierge-lxd --verbose --constraints arch=" + runtime.GOARCH + " --model-default automatically-retry-hooks=false --model-default test-mode=true --bootstrap-constraints arch=" + runtime.GOARCH,
 				"sudo -u test-user juju add-model -c concierge-lxd testing",
 			},
 			expectedDirs: []string{".local/share/juju"},
@@ -104,7 +105,7 @@ func TestJujuHandlerCommandsPresets(t *testing.T) {
 			expectedCommands: []string{
 				"snap install juju",
 				"sudo -u test-user juju show-controller concierge-microk8s",
-				"sudo -u test-user -g snap_microk8s juju bootstrap microk8s concierge-microk8s --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true",
+				"sudo -u test-user -g snap_microk8s juju bootstrap microk8s concierge-microk8s --verbose --constraints arch=" + runtime.GOARCH + " --model-default automatically-retry-hooks=false --model-default test-mode=true --bootstrap-constraints arch=" + runtime.GOARCH,
 				"sudo -u test-user juju add-model -c concierge-microk8s testing",
 			},
 			expectedDirs: []string{".local/share/juju"},
@@ -114,7 +115,7 @@ func TestJujuHandlerCommandsPresets(t *testing.T) {
 			expectedCommands: []string{
 				"snap install juju",
 				"sudo -u test-user juju show-controller concierge-k8s",
-				"sudo -u test-user juju bootstrap k8s concierge-k8s --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true --bootstrap-constraints root-disk=2G",
+				"sudo -u test-user juju bootstrap k8s concierge-k8s --verbose --constraints arch=" + runtime.GOARCH + " --model-default automatically-retry-hooks=false --model-default test-mode=true --bootstrap-constraints arch=" + runtime.GOARCH + " --bootstrap-constraints root-disk=2G",
 				"sudo -u test-user juju add-model -c concierge-k8s testing",
 			},
 			expectedDirs: []string{".local/share/juju"},


### PR DESCRIPTION
DRAFT: Not sure this is the correct solution for #68, but pushing up a test.