### PR TITLE
build: release snap for ppc64le arch

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - ppc64le
       - s390x
     ldflags:
       - -X github.com/canonical/concierge/cmd.version={{ .Version }} -X github.com/canonical/concierge/cmd.commit={{ .Commit }}

--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -66,7 +66,7 @@ func (m *MicroK8s) Prepare() error {
 
 	err = m.init()
 	if err != nil {
-		return fmt.Errorf("failed to install MicroK8s: %w", err)
+		return fmt.Errorf("failed to initialize MicroK8s: %w", err)
 	}
 
 	err = m.enableAddons()


### PR DESCRIPTION
Similar to #81 (s390x), this PR adds goreleaser for the ppc64le architecture.