### PR TITLE
chore: update TIOBE staticcheck dependency

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
           go install github.com/axw/gocov/gocov@v1.1.0
           go install github.com/AlekSi/gocov-xml@v1.1.0
 


### PR DESCRIPTION
Our TIOBE contact let us know we need to update the staticcheck tool they use to support Go 1.24.