### PR TITLE
ci: bump k8s snap version to fix integration tests

### DIFF
--- a/tests/overrides-env/task.yaml
+++ b/tests/overrides-env/task.yaml
@@ -9,7 +9,7 @@ execute: |
   export CONCIERGE_CHARMCRAFT_CHANNEL=latest/edge
   export CONCIERGE_ROCKCRAFT_CHANNEL=latest/edge
   export CONCIERGE_LXD_CHANNEL=latest/candidate
-  export CONCIERGE_K8S_CHANNEL=1.31-classic/beta
+  export CONCIERGE_K8S_CHANNEL=1.32-classic/stable
 
   export CONCIERGE_EXTRA_SNAPS="node/22/stable"
   export CONCIERGE_EXTRA_DEBS="make"
@@ -29,7 +29,7 @@ execute: |
   echo $list | MATCH latest/candidate
 
   list="$(snap list k8s)"
-  echo $list | MATCH 1.31-classic/beta
+  echo $list | MATCH 1.32-classic/stable
 
   list="$(snap list node)"
   echo $list | MATCH 22/stable


### PR DESCRIPTION
The `overrides-env` integration test is failing due to a `k8s` snap channel issue ([failed run here](https://github.com/canonical/concierge/actions/runs/17416378611/job/49445793227)), so attempt to fix that.