### PR TITLE
fix: enable cgo so user.Lookup uses libc version (and nsswitch.conf)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ builds:
     binary: concierge
     mod_timestamp: "{{ .CommitTimestamp }}"
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1  # enable libc versions of user.Lookup and the like
     goos:
       - linux
     goarch:

--- a/spread.yaml
+++ b/spread.yaml
@@ -96,7 +96,7 @@ prepare: |
 
   if [[ ! -f "$PWD/concierge" ]]; then
     sudo snap install go --classic
-    export CGO_ENABLED=0
+    export CGO_ENABLED=1  # enable libc versions of user.Lookup and the like
     go build -o concierge main.go
     chmod 755 concierge
   fi


### PR DESCRIPTION
See #99 for problem description. Let's set `CGO_ENABLED=1` (we could leave it off as that's the default, but probably better to be explicit) and see if that fixes it.

Fixes #99