### PR TITLE
ci: limit labels from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-
+    labels:
+      - "dependencies"
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: monthly
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Avoid dependabot creating language labels (particularly in this case "go") so that we have consistent labels across Charm Tech repositories.