### PR TITLE
feat: add an option to pass --agent-version when bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ juju:
   disable: true | false
   # (Optional): Channel from which to install Juju.
   channel: <channel>
+  # (Optional): Juju agent version to use when bootstrapping (e.g. "3.5.2").
+  agent-version: <version>
   # (Optional): A map of model-defaults to set when bootstrapping *all* Juju controllers.
   model-defaults:
     <model-default>: <value>
@@ -300,6 +302,7 @@ An example config file can be seen below:
 ```yaml
 juju:
   channel: 3.5/stable
+  agent-version: "3.5.2"
   model-defaults:
     test-mode: "true"
     automatically-retry-hooks: "false"

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -34,6 +34,8 @@ type jujuConfig struct {
 	Disable bool `mapstructure:"disable"`
 	// The Snap Store channel from which to install Juju
 	Channel string `mapstructure:"channel"`
+	// The Juju agent version to use during bootstrap
+	AgentVersion string `mapstructure:"agent-version"`
 	// The set of model-defaults to be passed to Juju during bootstrap
 	ModelDefaults map[string]string `mapstructure:"model-defaults"`
 	// The set of bootstrap constraints to be passed to Juju

--- a/internal/juju/juju.go
+++ b/internal/juju/juju.go
@@ -29,6 +29,7 @@ func NewJujuHandler(config *config.Config, r system.Worker, providers []provider
 
 	return &JujuHandler{
 		channel:              channel,
+		agentVersion:         config.Juju.AgentVersion,
 		bootstrapConstraints: config.Juju.BootstrapConstraints,
 		modelDefaults:        config.Juju.ModelDefaults,
 		providers:            providers,
@@ -40,6 +41,7 @@ func NewJujuHandler(config *config.Config, r system.Worker, providers []provider
 // JujuHandler represents a Juju installation on the system.
 type JujuHandler struct {
 	channel              string
+	agentVersion         string
 	bootstrapConstraints map[string]string
 	modelDefaults        map[string]string
 	providers            []providers.Provider
@@ -199,6 +201,11 @@ func (j *JujuHandler) bootstrapProvider(provider providers.Provider) error {
 		provider.CloudName(),
 		controllerName,
 		"--verbose",
+	}
+
+	// Add agent version if specified.
+	if j.agentVersion != "" {
+		bootstrapArgs = append(bootstrapArgs, "--agent-version", j.agentVersion)
 	}
 
 	// Combine the global and provider-local model-defaults and bootstrap-constraints.


### PR DESCRIPTION
Adds a new config option in `juju`, `agent-version`. When specified, this is passed as `--agent-version` when bootstrapping Juju.

This is particularly useful when there is an issue with the latest agent version and users want to restrict the agent version to one without the issue, but otherwise use the latest Juju.