### PR TITLE
fix: use a channel in the override test that is likely to stick around

### DIFF
--- a/tests/overrides-env/task.yaml
+++ b/tests/overrides-env/task.yaml
@@ -9,7 +9,7 @@ execute: |
   export CONCIERGE_CHARMCRAFT_CHANNEL=latest/edge
   export CONCIERGE_ROCKCRAFT_CHANNEL=latest/edge
   export CONCIERGE_LXD_CHANNEL=latest/candidate
-  export CONCIERGE_K8S_CHANNEL=1.31-classic/beta
+  export CONCIERGE_K8S_CHANNEL=1.34-classic/beta
 
   export CONCIERGE_EXTRA_SNAPS="node/22/stable"
   export CONCIERGE_EXTRA_DEBS="make"

--- a/tests/overrides-env/task.yaml
+++ b/tests/overrides-env/task.yaml
@@ -9,7 +9,7 @@ execute: |
   export CONCIERGE_CHARMCRAFT_CHANNEL=latest/edge
   export CONCIERGE_ROCKCRAFT_CHANNEL=latest/edge
   export CONCIERGE_LXD_CHANNEL=latest/candidate
-  export CONCIERGE_K8S_CHANNEL=1.34-classic/beta
+  export CONCIERGE_K8S_CHANNEL=latest/edge
 
   export CONCIERGE_EXTRA_SNAPS="node/22/stable"
   export CONCIERGE_EXTRA_DEBS="make"
@@ -29,7 +29,7 @@ execute: |
   echo $list | MATCH latest/candidate
 
   list="$(snap list k8s)"
-  echo $list | MATCH 1.31-classic/beta
+  echo $list | MATCH latest/edge
 
   list="$(snap list node)"
   echo $list | MATCH 22/stable

--- a/tests/overrides-env/task.yaml
+++ b/tests/overrides-env/task.yaml
@@ -16,7 +16,7 @@ execute: |
 
   "$SPREAD_PATH"/concierge --trace prepare -p k8s
 
-  for i in charmcraft rockcraft; do
+  for i in charmcraft rockcraft k8s; do
     list="$(snap list $i)"
     echo $list | MATCH $i
     echo $list | MATCH latest/edge
@@ -27,9 +27,6 @@ execute: |
 
   list="$(snap list lxd)"
   echo $list | MATCH latest/candidate
-
-  list="$(snap list k8s)"
-  echo $list | MATCH latest/edge
 
   list="$(snap list node)"
   echo $list | MATCH 22/stable


### PR DESCRIPTION
The `overrides-env` test currently tries to use the environment to override the default `k8s` channel to be `1.31-classic/beta`. This channel appears to have been removed at some point, which causes the test to now fail.

The PR changes the override to `latest/edge`, which seems likely to be around for a long time (the default is currently "1.32-classic/stable").