### PR TITLE
chore: show version when `go run` or `go install'ed` from a github release

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,15 +1,13 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 func rootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "concierge",
-		Version: fmt.Sprintf("%s (%s)", version, commit),
+		Version: appVersion(),
 		Short:   "A utility for configuring dev/test machines for charm development.",
 		Long: `concierge is an opinionated utility for provisioning charm development and testing machines.
 	


### PR DESCRIPTION
Fixes #59 

With this change, the version that the binary reports is either:
- what's passed via ldflags for artefacts built with gorelease
- what go tooling adds when build via `go run/build/install`

Tested with:

```command
⋊> dima@bb ⋊> /t/w/use cat ../go.work                                                                                                                                                                                                                 15:17:26
go 1.24.4

use ./use

replace github.com/canonical/concierge => github.com/dimaqq/concierge v1.0.7
⋊> dima@bb ⋊> /t/w/use go build github.com/canonical/concierge                                                                                                                                                                                        15:20:30
go: downloading github.com/dimaqq/concierge v1.0.7
...
⋊> dima@bb ⋊> /t/w/use ./concierge --version                                                                                                                                                                                                          15:20:48
concierge version 1.0.5 (dev)
```

I imagine it's a side-effect of this:

```command
⋊> dima@bb ⋊> /t/w/use go version -m ./concierge                                                                                                                                                                                                      15:17:51
./concierge: go1.24.4
        path    github.com/canonical/concierge
        mod     github.com/canonical/concierge  v1.0.5
        =>      github.com/dimaqq/concierge     v1.0.7  h1:4xU7CRvYFskNSW4mOXjCgxYCXew1G2dN0/aarm20Icw=

...
```

And the local build:
```command
⋊> dima@bb ⋊> /c/concierge on main ◦ go build -buildvcs=true .                                                                                                                                                                                        15:24:48
go: downloading golang.org/x/sys v0.31.0
go: downloading golang.org/x/crypto v0.36.0
⋊> dima@bb ⋊> /c/concierge on main ◦ ./concierge --version                                                                                                                                                                                            15:25:08
concierge version 1.0.7+dirty (e33b77558d819b58fdea126b2f605b40368df179)
```

So, it kindof works, but would need an actual test tag in the official remote to be properly tested.