### PR TITLE
chore: bump go directive to 1.26.5 (backport #239 to 1.5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/concierge
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b


### PR DESCRIPTION
Backport of #239.