### PR TITLE
ci: add a workshop for the dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .spread-reuse*.yaml
 /.idea
 /.claude/settings.local.json
+.workshop.lock

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -1,0 +1,6 @@
+name: dev
+base: ubuntu@26.04
+sdks:
+  - name: go
+    channel: 1.26/stable
+  - name: project-tools

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -3,6 +3,11 @@ base: ubuntu@24.04
 sdks:
   - name: go
     channel: 1.26/stable
+  # The Pi agent harness needs Node 22.19 or newer; 24.04 ships Node 18. The
+  # store SDK is a cached volume, where installing Node by hand in a hook is
+  # ~60s of apt and network on every single launch.
+  - name: node
+    channel: 22/stable
   - name: project-tools
 
 actions:

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -1,6 +1,21 @@
 name: dev
-base: ubuntu@26.04
+base: ubuntu@24.04
 sdks:
   - name: go
     channel: 1.26/stable
   - name: project-tools
+
+actions:
+  build: go build ./... "$@"
+  run: go run . "$@"
+  test: go test "${@:-./...}"
+  vet: go vet "${@:-./...}"
+
+# There is deliberately no spread action. The integration suites in tests/ ask
+# concierge to reshape the machine it runs on -- lxd init, snap installs, Juju
+# bootstrap, MicroK8s/k8s -- which an unprivileged container cannot host, and
+# spread expects a disposable system where this workshop is long-lived. Run them
+# on the host instead, against the lxd backend, which builds a fresh VM per run:
+#
+#   spread -v lxd:
+#   spread -v lxd:ubuntu-24.04:tests/juju-model-defaults

--- a/.workshop/tools/hooks/setup-base
+++ b/.workshop/tools/hooks/setup-base
@@ -1,0 +1,3 @@
+# Node and npm are required by the Pi agent harness
+apt-get update
+apt-get install nodejs npm

--- a/.workshop/tools/hooks/setup-base
+++ b/.workshop/tools/hooks/setup-base
@@ -1,7 +1,0 @@
-# Node and npm are required by the Pi agent harness, which needs Node 22.19 or
-# newer. Ubuntu 24.04 ships Node 18, so install from NodeSource rather than
-# relying on the distro packages.
-apt-get update
-apt-get install -y ca-certificates curl gnupg
-curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-apt-get install -y nodejs

--- a/.workshop/tools/hooks/setup-base
+++ b/.workshop/tools/hooks/setup-base
@@ -1,3 +1,7 @@
-# Node and npm are required by the Pi agent harness
+# Node and npm are required by the Pi agent harness, which needs Node 22.19 or
+# newer. Ubuntu 24.04 ships Node 18, so install from NodeSource rather than
+# relying on the distro packages.
 apt-get update
-apt-get install nodejs npm
+apt-get install -y ca-certificates curl gnupg
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+apt-get install -y nodejs

--- a/.workshop/tools/hooks/setup-project
+++ b/.workshop/tools/hooks/setup-project
@@ -1,0 +1,2 @@
+# Pi agent harness
+curl -fsSL https://pi.dev/install.sh | sh

--- a/.workshop/tools/sdk.yaml
+++ b/.workshop/tools/sdk.yaml
@@ -1,0 +1,6 @@
+name: tools
+
+plugs:
+  pi-data:
+    interface: mount
+    workshop-target: /home/workshop/.pi

--- a/.workshop/tools/sdk.yaml
+++ b/.workshop/tools/sdk.yaml
@@ -1,5 +1,9 @@
 name: tools
 
+# Pi keeps its config and credentials in ~/.pi. A mount plug is auto-connected
+# to system:mount and backed by a Workshop-allocated host directory, so that
+# state survives `workshop refresh`/`start`/`stop` and the agent doesn't need
+# re-authenticating after every rebuild.
 plugs:
   pi-data:
     interface: mount


### PR DESCRIPTION
This is the same shape as the workshop that just landed in pebble (canonical/pebble#912): a single `dev` workshop on `ubuntu@24.04` with the Go SDK on `1.26/stable` and a local `project-tools` SDK that installs the Pi agent harness.

Fixes #199
