### PR TITLE
feat: let image-registry target a registry other than docker.io

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,9 +48,12 @@ providers:
     # (Optional) MicroK8s addons to enable.
     addons:
       - <addon>[:<params>]
-    # (Optional) Image registry mirror. Values support ${VAR} interpolation.
+    # (Optional) Image registry: a Docker Hub mirror, or a private registry
+    # such as ghcr.io. Values support ${VAR} interpolation.
     image-registry:
       url: <url>
+      # (Optional) Registry to configure. Defaults to docker.io.
+      registry: <hostname>
       username: <username>
       password: <password>
 
@@ -66,8 +69,12 @@ providers:
     features:
       <feature>:
         <key>: <value>
+    # (Optional) Image registry: a Docker Hub mirror, or a private registry
+    # such as ghcr.io. Values support ${VAR} interpolation.
     image-registry:
       url: <url>
+      # (Optional) Registry to configure. Defaults to docker.io.
+      registry: <hostname>
       username: <username>
       password: <password>
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,11 +216,13 @@ func expandEnvVars(s string) string {
 func expandConfigEnvVars(conf *Config) {
 	// Expand in MicroK8s image registry config
 	conf.Providers.MicroK8s.ImageRegistry.URL = expandEnvVars(conf.Providers.MicroK8s.ImageRegistry.URL)
+	conf.Providers.MicroK8s.ImageRegistry.Registry = expandEnvVars(conf.Providers.MicroK8s.ImageRegistry.Registry)
 	conf.Providers.MicroK8s.ImageRegistry.Username = expandEnvVars(conf.Providers.MicroK8s.ImageRegistry.Username)
 	conf.Providers.MicroK8s.ImageRegistry.Password = expandEnvVars(conf.Providers.MicroK8s.ImageRegistry.Password)
 
 	// Expand in K8s image registry config
 	conf.Providers.K8s.ImageRegistry.URL = expandEnvVars(conf.Providers.K8s.ImageRegistry.URL)
+	conf.Providers.K8s.ImageRegistry.Registry = expandEnvVars(conf.Providers.K8s.ImageRegistry.Registry)
 	conf.Providers.K8s.ImageRegistry.Username = expandEnvVars(conf.Providers.K8s.ImageRegistry.Username)
 	conf.Providers.K8s.ImageRegistry.Password = expandEnvVars(conf.Providers.K8s.ImageRegistry.Password)
 }

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -75,11 +75,29 @@ type googleConfig struct {
 	BootstrapConstraints map[string]string `yaml:"bootstrap-constraints"`
 }
 
-// ImageRegistryConfig represents configuration for an image registry mirror.
+// ImageRegistryConfig represents configuration for an image registry.
+//
+// The Registry field names the target registry (e.g. "ghcr.io"); when empty
+// it defaults to "docker.io" for backward compatibility with configs that
+// only ever mirrored Docker Hub. Setting it to something else lets users
+// point at a private registry directly — for example, to hand a k8s or
+// microk8s cluster credentials for ghcr.io — without having to configure a
+// mirror at all.
 type ImageRegistryConfig struct {
 	URL      string `yaml:"url"`
+	Registry string `yaml:"registry"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+}
+
+// TargetRegistry returns the target registry hostname, defaulting to
+// "docker.io" when the Registry field is unset. This is used as the
+// per-registry subdirectory name for containerd's certs.d / hosts.d layout.
+func (c ImageRegistryConfig) TargetRegistry() string {
+	if c.Registry == "" {
+		return "docker.io"
+	}
+	return c.Registry
 }
 
 // microk8sConfig represents how MicroK8s should be configured on the host.

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -77,7 +77,7 @@ type googleConfig struct {
 
 // ImageRegistryConfig represents configuration for an image registry.
 //
-// The Registry field names the target registry (e.g. "ghcr.io"); when empty
+// The Registry field names the target registry (such as "ghcr.io"); when empty
 // it defaults to "docker.io" for backward compatibility with configs that
 // only ever mirrored Docker Hub. Setting it to something else lets users
 // point at a private registry directly — for example, to hand a k8s or

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -320,6 +320,96 @@ providers:
 	}
 }
 
+func TestImageRegistryTargetRegistryDefaults(t *testing.T) {
+	// Empty Registry field falls back to docker.io — preserves the historical
+	// mirror behaviour for existing configs that never set it.
+	empty := ImageRegistryConfig{URL: "https://mirror.example.com"}
+	if got := empty.TargetRegistry(); got != "docker.io" {
+		t.Fatalf("expected default target 'docker.io', got: %v", got)
+	}
+
+	// A set Registry field is returned verbatim.
+	ghcr := ImageRegistryConfig{URL: "https://ghcr.io", Registry: "ghcr.io"}
+	if got := ghcr.TargetRegistry(); got != "ghcr.io" {
+		t.Fatalf("expected target 'ghcr.io', got: %v", got)
+	}
+}
+
+func TestImageRegistryRegistryFromYAML(t *testing.T) {
+	yamlConfig := `
+providers:
+  microk8s:
+    enable: true
+    bootstrap: true
+    image-registry:
+      registry: ghcr.io
+      url: https://ghcr.io
+      username: gh-user
+      password: gh-pat
+`
+
+	tmpFile, err := os.CreateTemp("", "concierge-test-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	if _, err := tmpFile.Write([]byte(yamlConfig)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := parseConfig(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	if got := cfg.Providers.MicroK8s.ImageRegistry.Registry; got != "ghcr.io" {
+		t.Fatalf("expected Registry 'ghcr.io', got: %v", got)
+	}
+	if got := cfg.Providers.MicroK8s.ImageRegistry.TargetRegistry(); got != "ghcr.io" {
+		t.Fatalf("expected TargetRegistry 'ghcr.io', got: %v", got)
+	}
+}
+
+func TestImageRegistryRegistryEnvVarExpansion(t *testing.T) {
+	t.Setenv("PRIVATE_REGISTRY_HOST", "ghcr.io")
+
+	yamlConfig := `
+providers:
+  microk8s:
+    enable: true
+    bootstrap: true
+    image-registry:
+      registry: $PRIVATE_REGISTRY_HOST
+      url: https://ghcr.io
+`
+
+	tmpFile, err := os.CreateTemp("", "concierge-test-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	if _, err := tmpFile.Write([]byte(yamlConfig)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := parseConfig(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	if got := cfg.Providers.MicroK8s.ImageRegistry.Registry; got != "ghcr.io" {
+		t.Fatalf("expected Registry expanded to 'ghcr.io', got: %v", got)
+	}
+}
+
 func TestImageRegistryEnvVarExpansion(t *testing.T) {
 	// Set test environment variables
 	t.Setenv("DOCKERHUB_MIRROR", "https://dockerhub-mirror.example.com")

--- a/internal/providers/k8s.go
+++ b/internal/providers/k8s.go
@@ -153,7 +153,7 @@ func (k *K8s) restoreImageRegistry() {
 		return
 	}
 
-	hostsDir := "/etc/containerd/hosts.d/docker.io"
+	hostsDir := path.Join("/etc/containerd/hosts.d", k.ImageRegistry.TargetRegistry())
 	slog.Debug("Removing image registry configuration", "path", hostsDir)
 	if err := k.system.RemovePath(hostsDir); err != nil {
 		slog.Warn("Failed to remove image registry configuration", "path", hostsDir, "error", err)
@@ -325,18 +325,21 @@ func (k *K8s) restoreContainerd() {
 	slog.Debug("Successfully started containerd service")
 }
 
-// configureImageRegistry configures an image registry mirror for K8s.
-// This allows using alternative registries like internal mirrors for docker.io.
+// configureImageRegistry configures an image registry for K8s.
+// This allows using alternative registries — either an internal mirror for
+// docker.io (the default target) or a private registry like ghcr.io by
+// setting `image-registry.registry` in the config. The k8s snap uses
+// containerd with hosts.d configuration at /etc/containerd/hosts.d/.
 func (k *K8s) configureImageRegistry() error {
 	if k.ImageRegistry.URL == "" {
 		return nil
 	}
 
-	slog.Info("Configuring image registry", "url", k.ImageRegistry.URL)
+	target := k.ImageRegistry.TargetRegistry()
+	slog.Info("Configuring image registry", "url", k.ImageRegistry.URL, "target", target)
 
-	// Create the hosts.d directory for docker.io registry configuration
-	// The k8s snap uses containerd with hosts.d configuration at /etc/containerd/hosts.d/
-	hostsDir := "/etc/containerd/hosts.d/docker.io"
+	// Create the hosts.d directory for the target registry.
+	hostsDir := path.Join("/etc/containerd/hosts.d", target)
 	err := k.system.MkdirAll(hostsDir, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create hosts directory: %w", err)

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -363,6 +363,73 @@ func TestK8sRestoreWithoutImageRegistryLeavesHostsDirAlone(t *testing.T) {
 	}
 }
 
+func TestK8sPrepareWithNonDockerHubRegistry(t *testing.T) {
+	// Configure credentials for ghcr.io directly, without any docker.io mirror.
+	// Verifies that setting `image-registry.registry` puts hosts.toml under
+	// hosts.d/<registry>/ instead of the hardcoded docker.io path.
+	cfg := &config.Config{}
+	cfg.Providers.K8s.Channel = defaultK8sChannel
+	cfg.Providers.K8s.Features = map[string]map[string]string{}
+	cfg.Providers.K8s.ImageRegistry.URL = "https://ghcr.io"
+	cfg.Providers.K8s.ImageRegistry.Registry = "ghcr.io"
+	cfg.Providers.K8s.ImageRegistry.Username = "gh-user"
+	cfg.Providers.K8s.ImageRegistry.Password = "gh-pat"
+
+	sys := system.NewMockSystem()
+	sys.MockCommandReturn("which iptables", []byte("/usr/sbin/iptables"), nil)
+	ck8s := NewK8s(sys, cfg)
+	if err := ck8s.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+
+	ghcrPath := "/etc/containerd/hosts.d/ghcr.io/hosts.toml"
+	hostsToml, ok := sys.CreatedFiles[ghcrPath]
+	if !ok {
+		t.Fatalf("expected hosts.toml at %q, got files: %v", ghcrPath, sys.CreatedFiles)
+	}
+
+	// The docker.io path must not have been created.
+	if _, ok := sys.CreatedFiles["/etc/containerd/hosts.d/docker.io/hosts.toml"]; ok {
+		t.Fatalf("did not expect docker.io hosts.toml, got: %v", sys.CreatedFiles)
+	}
+
+	if !strings.Contains(hostsToml, `server = "https://ghcr.io"`) {
+		t.Fatalf("expected hosts.toml to point at ghcr.io, got: %v", hostsToml)
+	}
+	if !strings.Contains(hostsToml, "Authorization = [\"Basic") {
+		t.Fatalf("expected hosts.toml to contain authorization header, got: %v", hostsToml)
+	}
+}
+
+func TestK8sRestoreRemovesNonDockerHubRegistry(t *testing.T) {
+	// Verifies that Restore also cleans up the certs.d subdirectory for the
+	// configured target registry, not just docker.io.
+	cfg := &config.Config{}
+	cfg.Providers.K8s.Channel = ""
+	cfg.Providers.K8s.Features = defaultFeatureConfig
+	cfg.Providers.K8s.ImageRegistry.URL = "https://ghcr.io"
+	cfg.Providers.K8s.ImageRegistry.Registry = "ghcr.io"
+	cfg.Providers.K8s.ImageRegistry.Username = "gh-user"
+	cfg.Providers.K8s.ImageRegistry.Password = "gh-pat"
+
+	sys := system.NewMockSystem()
+	sys.MockCommandReturn("systemctl list-unit-files containerd.service", []byte("0 unit files listed."), nil)
+
+	ck8s := NewK8s(sys, cfg)
+	if err := ck8s.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRemovedPaths := []string{
+		path.Join(os.TempDir(), ".kube"),
+		"/etc/containerd/hosts.d/ghcr.io",
+	}
+
+	if !slices.Equal(expectedRemovedPaths, sys.RemovedPaths) {
+		t.Fatalf("expected: %v, got: %v", expectedRemovedPaths, sys.RemovedPaths)
+	}
+}
+
 func TestK8sBuildHostsToml(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Providers.K8s.Channel = defaultK8sChannel

--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -157,17 +157,20 @@ func (m *MicroK8s) install() error {
 	return nil
 }
 
-// configureImageRegistry configures an image registry mirror for MicroK8s.
-// This allows using alternative registries like internal mirrors for docker.io.
+// configureImageRegistry configures an image registry for MicroK8s.
+// This allows using alternative registries — either an internal mirror for
+// docker.io (the default target) or a private registry like ghcr.io by
+// setting `image-registry.registry` in the config.
 func (m *MicroK8s) configureImageRegistry() error {
 	if m.ImageRegistry.URL == "" {
 		return nil
 	}
 
-	slog.Info("Configuring image registry", "url", m.ImageRegistry.URL)
+	target := m.ImageRegistry.TargetRegistry()
+	slog.Info("Configuring image registry", "url", m.ImageRegistry.URL, "target", target)
 
-	// Create the certs.d directory for docker.io registry configuration
-	certsDir := "/var/snap/microk8s/current/args/certs.d/docker.io"
+	// Create the certs.d directory for the target registry.
+	certsDir := path.Join("/var/snap/microk8s/current/args/certs.d", target)
 	err := m.system.MkdirAll(certsDir, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create certs directory: %w", err)

--- a/internal/providers/microk8s_test.go
+++ b/internal/providers/microk8s_test.go
@@ -246,6 +246,43 @@ func TestMicroK8sPrepareWithImageRegistryAndAuth(t *testing.T) {
 	}
 }
 
+func TestMicroK8sPrepareWithNonDockerHubRegistry(t *testing.T) {
+	// Configure credentials for ghcr.io directly, without any docker.io mirror.
+	// Verifies that setting `image-registry.registry` puts hosts.toml under
+	// certs.d/<registry>/ instead of the hardcoded docker.io path.
+	cfg := &config.Config{}
+	cfg.Providers.MicroK8s.Channel = "1.31-strict/stable"
+	cfg.Providers.MicroK8s.Addons = []string{}
+	cfg.Providers.MicroK8s.ImageRegistry.URL = "https://ghcr.io"
+	cfg.Providers.MicroK8s.ImageRegistry.Registry = "ghcr.io"
+	cfg.Providers.MicroK8s.ImageRegistry.Username = "gh-user"
+	cfg.Providers.MicroK8s.ImageRegistry.Password = "gh-pat"
+
+	sys := system.NewMockSystem()
+	uk8s := NewMicroK8s(sys, cfg)
+	if err := uk8s.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+
+	ghcrPath := "/var/snap/microk8s/current/args/certs.d/ghcr.io/hosts.toml"
+	hostsToml, ok := sys.CreatedFiles[ghcrPath]
+	if !ok {
+		t.Fatalf("expected hosts.toml at %q, got files: %v", ghcrPath, sys.CreatedFiles)
+	}
+
+	// The docker.io path must not have been created.
+	if _, ok := sys.CreatedFiles["/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml"]; ok {
+		t.Fatalf("did not expect docker.io hosts.toml, got: %v", sys.CreatedFiles)
+	}
+
+	if !strings.Contains(hostsToml, `server = "https://ghcr.io"`) {
+		t.Fatalf("expected hosts.toml to point at ghcr.io, got: %v", hostsToml)
+	}
+	if !strings.Contains(hostsToml, "Authorization = [\"Basic") {
+		t.Fatalf("expected hosts.toml to contain authorization header, got: %v", hostsToml)
+	}
+}
+
 func TestMicroK8sBuildHostsToml(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Providers.MicroK8s.Channel = "1.31-strict/stable"


### PR DESCRIPTION
`configureImageRegistry` hardcodes the certs.d subdirectory as `docker.io` in both providers, so the only registry you can configure is Docker Hub - either directly or as a mirror endpoint. That means there's no way to hand k8s or MicroK8s pull credentials for a private registry.

This adds an optional `registry` field to `image-registry`, defaulting to `docker.io`, and uses it as the directory name. Existing configs behave exactly as before. `restore` now removes the directory for the configured registry rather than always removing `docker.io`, so credentials for a non-Docker-Hub registry are cleaned up.

The spread tests under `tests/{k8s,microk8s}-image-registry/` still exercise the Docker Hub path only; adding a ghcr.io case there would need a registry to authenticate against.

Fixes #181
