### PR TITLE
docs: publish to Read the Docs

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    post_checkout:
+    - git fetch --unshallow || true
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: dirhtml
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/_static/overwrite_links.js
+++ b/docs/_static/overwrite_links.js
@@ -1,0 +1,28 @@
+// Our docs are proxied through to canonical.com/juju/docs/jubilant.
+// If multiple doc versions are configured, Read the Docs renders a version switcher.
+// The version switcher has the readthedocs-hosted.com URL in links, which we don't want,
+// so this script overwrites those links to use the correct public-facing URL.
+
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-juju-jubilant.readthedocs-hosted.com';
+const newDomain = 'canonical.com/juju/docs/jubilant';
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        const anchors = shadowRoot.querySelectorAll('a');
+        anchors.forEach(anchor => {
+            anchor.href = anchor.href.replace(new RegExp(oldDomain, 'g'), newDomain);
+        });
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ copyright = f"{datetime.date.today().year}"
 html_title = project + " documentation"
 
 # Documentation website URL
-ogp_site_url = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+ogp_site_url = "https://canonical.com/juju/docs/concierge/"
 
 # Preview name of the documentation website
 ogp_site_name = project
@@ -87,19 +87,19 @@ html_theme_options = {
 }
 
 # Project slug
-# If your documentation is hosted on https://documentation.ubuntu.com/,
-# uncomment and set to the RTD slug.
-# slug = ''
+# Set to the path after https://canonical.com/
+slug = "juju/docs/concierge"
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
 #######################
 
-# Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+# Used for the canonical URL of each page
+html_baseurl = "https://canonical.com/juju/docs/concierge/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 sitemap_url_scheme = "{link}"
+sitemap_filename = "doc-sitemap.xml"
 
 # Include `lastmod` dates in the sitemap:
 sitemap_show_lastmod = True
@@ -223,6 +223,7 @@ html_css_files = [
 # Adds custom JavaScript files, located remotely or in 'html_static_path'.
 html_js_files = [
     "https://assets.ubuntu.com/v1/287a5e8f-bundle.js",
+    "overwrite_links.js",
 ]
 
 # Appends extra markup to the end of every document written in reST


### PR DESCRIPTION
This PR enables Read the Docs builds and prepares for publishing the docs at https://canonical.com/juju/docs/concierge/.

Next steps:

1. Merge this PR, which should then trigger a (private) RTD build.
2. Update Canonical's proxy configuration to serve the RTD build at https://canonical.com/juju/docs/concierge/.
3. Open another Concierge PR to update the Documentation section of the README, and any other places that need to link to the published docs.