### PR TITLE
docs: link to newly-published docs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,7 @@ snapcrafts:
 
       Its role is to ensure that a given machine has the relevant "craft" tools and providers
       installed, then bootstrap a Juju controller onto each of the providers. Additionally, it can
-      install selected tools from the [snap store](https://snapcraft.io) or the Ubuntu archive.
+      install selected tools from the Snap Store or the Ubuntu archive.
 
       Configuration is by flags/environment variables, or by configuration file. The configuration file
       must be in the current working directory and named 'concierge.yaml', or the path specified using

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,7 +49,7 @@ snapcrafts:
       Each of the override flags has an environment variable equivalent, such as
       'CONCIERGE_JUJU_CHANNEL'.
 
-      More information at https://github.com/canonical/concierge.
+      More information at https://canonical.com/juju/docs/concierge/.
     extra_files:
       - source: .github/concierge.png
         destination: concierge.png

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ To help us review your changes, please rebase your pull request onto the `main` 
 
 ## AI
 
-You're welcome to submit pull requests that are partly or entirely generated using generative AI tools. However, you must review the code yourself bgithub.com/canonical/conciergeefore moving the PR out of draft -- by submitting the PR, you are claiming personal responsibility for its quality and suitability. If you are not capable of reviewing the PR (for example, if you are not fluent in Go, or are not familiar with Concierge), please do not submit the PR (maybe you'd like to open an issue instead). PRs that are clearly (co-)authored by tools will be closed without review unless there is a human author that claims responsibility for the PR.
+You're welcome to submit pull requests that are partly or entirely generated using generative AI tools. However, you must review the code yourself before moving the PR out of draft -- by submitting the PR, you are claiming personal responsibility for its quality and suitability. If you are not capable of reviewing the PR (for example, if you are not fluent in Go, or are not familiar with Concierge), please do not submit the PR (maybe you'd like to open an issue instead). PRs that are clearly (co-)authored by tools will be closed without review unless there is a human author that claims responsibility for the PR.
 
 Please do not use tools (such as GitHub Copilot) to provide PR reviews. The Charm Tech team also has access to these tools, and will use them when appropriate.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ To help us review your changes, please rebase your pull request onto the `main` 
 
 ## AI
 
-You're welcome to submit pull requests that are partly or entirely generated using generative AI tools. However, you must review the code yourself before moving the PR out of draft -- by submitting the PR, you are claiming personal responsibility for its quality and suitability. If you are not capable of reviewing the PR (for example, if you are not fluent in Go, or are not familiar with Concierge), please do not submit the PR (maybe you'd like to open an issue instead). PRs that are clearly (co-)authored by tools will be closed without review unless there is a human author that claims responsibility for the PR.
+You're welcome to submit pull requests that are partly or entirely generated using generative AI tools. However, you must review the code yourself bgithub.com/canonical/conciergeefore moving the PR out of draft -- by submitting the PR, you are claiming personal responsibility for its quality and suitability. If you are not capable of reviewing the PR (for example, if you are not fluent in Go, or are not familiar with Concierge), please do not submit the PR (maybe you'd like to open an issue instead). PRs that are clearly (co-)authored by tools will be closed without review unless there is a human author that claims responsibility for the PR.
 
 Please do not use tools (such as GitHub Copilot) to provide PR reviews. The Charm Tech team also has access to these tools, and will use them when appropriate.
 
@@ -112,3 +112,11 @@ To release, simply create a new release in GitHub.
 5. Click "Publish release".
 6. Monitor the release [GitHub Action](https://github.com/canonical/concierge/actions) and check that the [snap](https://snapcraft.io/concierge) is uploaded correctly (it will have been published to all risks, including `stable`)
 7. Find the security scan artifact on the corresponding [SBOM and secscan](https://github.com/canonical/concierge/actions/workflows/sbom-secscan.yaml) run, and upload it to the [SSDLC Concierge folder in Drive](https://drive.google.com/drive/folders/1RtAn7x0EX97C6eV66xs74Pwth3KW7NHI?usp=share_link). Open the artifact and verify that the security scan has not found any vulnerabilities.
+
+## Building the docs locally
+
+The docs use Canonical's [Sphinx Stack](https://github.com/canonical/sphinx-stack). To build and browse the docs locally:
+
+```shell
+make -C docs run
+```

--- a/README.md
+++ b/README.md
@@ -24,14 +24,10 @@ sudo concierge prepare -p dev
 
 ## Documentation
 
-The full documentation lives in [`docs/`](docs/) and covers:
+See the [full documentation](https://canonical.com/juju/docs/concierge/) for:
 
-- [how-to guides](docs/how-to/) for common tasks such as [writing a custom config](docs/how-to/write-a-custom-config.md);
-- [reference](docs/reference/) for commands, the configuration schema, environment variables, and the built-in presets;
-- [explanation](docs/explanation/) of what Concierge is for and why `prepare` and `restore` are strict opposites.
+- Common tasks such as [writing a custom config](https://canonical.com/juju/docs/concierge/how-to/write-a-custom-config/)
+- The [configuration schema](https://canonical.com/juju/docs/concierge/reference/configuration/) and [presets](https://canonical.com/juju/docs/concierge/reference/presets/)
+- A deeper explanation of [what Concierge is for](https://canonical.com/juju/docs/concierge/explanation/what-is-concierge/)
 
-To build and browse the docs locally:
-
-```shell
-make -C docs run
-```
+And more!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,7 +66,7 @@ Concierge does not add any risks over manually installing and configuring the Sn
 
 ## Good practice
 
-If you are [providing credentials to Concierge](https://github.com/canonical/concierge/?tab=readme-ov-file#providing-credentials-files) for clouds, ensure that these are stored securely.
+If you are [providing credentials to Concierge](https://canonical.com/juju/docs/concierge/how-to/provide-credentials/) for clouds, ensure that these are stored securely.
 
 ## Security logging
 

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -29,7 +29,7 @@ Some aspects of presets and config files can be overridden using flags such as '
 Each of the override flags has an environment variable equivalent,
 such as 'CONCIERGE_JUJU_CHANNEL'.
 
-More information at https://github.com/canonical/concierge.
+More information at https://canonical.com/juju/docs/concierge/reference/commands/.
 `, presetList),
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -29,7 +29,7 @@ Some aspects of presets and config files can be overridden using flags such as '
 Each of the override flags has an environment variable equivalent,
 such as 'CONCIERGE_JUJU_CHANNEL'.
 
-More information at https://canonical.com/juju/docs/concierge/reference/commands/.
+More information at https://canonical.com/juju/docs/concierge/.
 `, presetList),
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ func rootCmd() *cobra.Command {
 	
 Its role is to ensure that a given machine has the relevant "craft" tools and providers installed,
 then bootstrap a Juju controller onto each of the providers. Additionally, it can install selected
-tools from the [snap store](https://snapcraft.io) or the Ubuntu archive.
+tools from the Snap Store or the Ubuntu archive.
 	`,
 		SilenceErrors: true,
 		SilenceUsage:  true,


### PR DESCRIPTION
The new docs are now live at https://canonical.com/juju/docs/concierge/!

This PR links to them from various user-facing places.

@tonyandrewmeyer this is my initial impression of what needs doing. If you have other ideas, please push changes to my branch.