### PR TITLE
docs: describe Concierge's security model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,44 +34,9 @@ policy](https://ubuntu.com/security/disclosure-policy) contains more
 information about what you can expect when you contact us, and what we
 expect from you.
 
-## Cryptographic technology
+## Security model
 
-Concierge uses cryptographic technology to securely download Snaps and Debian packages from the Ubuntu archive to install. Some of those tools, such as Juju, will in turn use crytographic technology to securely download images and other data needed to initialise.
-
-Concierge uses `apt` to install Debian packages, and `snap` to install Snaps.
-
-> See more:
->  - [Debian | SecureApt](https://wiki.debian.org/SecureApt)
->  - [Ubuntu Community | SecureApt](https://help.ubuntu.com/community/SecureApt)
->  - [Snap | Cryptography](https://snapcraft.io/docs/security-policies#p-2741-cryptography)
-
-## Hardening
-
-No additional steps are required to harden your system when using Concierge.
-
-> See also:
->  - [Juju | Harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#harden-your-deployment)
->  - [MicroK8s | CIS cluster hardening](https://microk8s.io/docs/cis-compliance)
->  - [Canonical K8s | Hardening guide](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/hardening/)
-
-## Risks
-
-Concierge does not add any risks over manually installing and configuring the Snaps and other packages included in the presets. However, users should be familiar with the security of each of the installed products.
-
-> See also:
->  - [Juju Security](https://documentation.ubuntu.com/juju/3.6/explanation/juju-security/)
->  - [LXD Security](https://documentation.ubuntu.com/lxd/stable-5.21/explanation/security/)
->  - [Canonical K8s Security](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/)
-
-
-## Good practice
-
-If you are [providing credentials to Concierge](https://canonical.com/juju/docs/concierge/how-to/provide-credentials/) for clouds, ensure that these are stored securely.
-
-## Security logging
-
-Concierge emits structured security events (privileged command execution, filesystem ownership changes, credential file writes, and provisioning start/stop) to the system journal under the `concierge` syslog identifier, following the [OWASP Application Logging Vocabulary](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Vocabulary_Cheat_Sheet.html). View them with:
-
-```
-journalctl -t concierge -o cat | jq .
-```
+Concierge's trust boundaries, the files it writes, the cryptography it relies
+on, how to harden and operate a machine it provisioned, the security events it
+emits, and how to decommission are documented in
+[Security](https://canonical.com/juju/docs/concierge/explanation/security/).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,6 +192,7 @@ extensions = [
     "sphinx_reredirects",
     "sphinx_tabs.tabs",
     "sphinxcontrib.jquery",
+    "sphinxcontrib.mermaid",
     "sphinxext.opengraph",
     "sphinx_config_options",
     "sphinx_contributor_listing",

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -1,12 +1,228 @@
 ---
 myst:
   html_meta:
-    description: How to report security issues in Concierge.
+    description: Concierge's trust boundaries, the files it writes, the security events it emits, and how to report a vulnerability.
 ---
 
 (security)=
 # Security
 
-To report a security issue in Concierge, follow the instructions in [SECURITY.md](https://github.com/canonical/concierge/blob/main/SECURITY.md). The preferred reporting channel is a private [GitHub security advisory](https://github.com/canonical/concierge/security/advisories/new).
+Concierge provisions a machine for charm development. It runs as root, installs
+snaps and Debian packages, bootstraps Juju controllers, and writes credentials
+into the home directory of the user who invoked it.
 
-This page will be expanded in a future release with a full description of Concierge's security model.
+Concierge is for throwaway machines: virtual machines, CI runners, and
+dedicated test hosts. Don't run it on your daily workstation. See
+[](explanation-prepare-restore-opposites) for why.
+
+## Product architecture
+
+Concierge is a short-lived command, not a daemon. It reads a configuration,
+runs a sequence of privileged commands, and exits.
+
+```{mermaid}
+flowchart LR
+    User["Invoking user<br/>(via sudo)"]
+    Config["Preset, config file,<br/>environment, flags"]
+    Concierge["concierge<br/>(runs as root)"]
+    Packages["snapd, APT"]
+    Providers["LXD, Canonical K8s,<br/>MicroK8s"]
+    Juju["Juju controllers"]
+    Home["User's home directory<br/>(credentials, kubeconfig,<br/>cached config)"]
+    Journal["System journal"]
+
+    User -->|invokes| Concierge
+    Config -->|read by| Concierge
+    Concierge -->|installs packages| Packages
+    Concierge -->|configures| Providers
+    Concierge -->|bootstraps| Juju
+    Concierge -->|writes files| Home
+    Concierge -->|security events| Journal
+```
+
+Three boundaries matter.
+
+The first is the jump to root. Concierge is invoked with `sudo`, and everything
+it does afterwards runs with full privileges. It executes its steps as shell
+commands, which is deliberate: Concierge is a wrapper around the same commands
+you would otherwise run by hand.
+
+The second is the configuration. A preset, a config file, environment
+variables, and command-line flags all feed the same plan, and that plan decides
+which commands run as root. Treat a `concierge.yaml` file as you would a
+shell script.
+
+The third is the user's home directory. Concierge writes files there as root
+and then changes their ownership to the invoking user. See
+[](#files-concierge-writes).
+
+Concierge opens no listening ports and runs no background process. Once it
+exits, you interact with the tools it installed directly.
+
+## Secure by design
+
+Concierge adds no privileges beyond those needed to install and configure the
+same tools by hand. It implements no cryptography, no authentication, and no
+network service of its own.
+
+The tool is declarative, so the set of privileged actions is determined by
+configuration you can read, diff, and commit before it runs. `concierge
+prepare --dry-run` prints what would happen without changing anything.
+
+Credentials are never written to the security event log. When Concierge records
+that it wrote a credentials file, the event carries the path and the number of
+clouds, not the contents.
+
+(files-concierge-writes)=
+## Files Concierge writes
+
+Concierge writes three files into the home directory of the user it is
+provisioning for. All three can contain secrets, and all three are written
+mode 0600, readable only by that user.
+
+| File | Contains |
+| :--- | :--- |
+| `~/.local/share/juju/credentials.yaml` | Juju cloud credentials, including any Google service-account credentials you supplied |
+| `~/.kube/config` | Kubernetes cluster credentials, when a Kubernetes provider is configured |
+| `~/.cache/concierge/concierge.yaml` | The merged runtime configuration, including the image registry password when one is configured |
+
+Concierge also reads a credentials file you provide for the Google provider,
+through `--google-credential-file` or the `google.credentials-file` config key.
+Concierge doesn't change that file's permissions. Store it as you would any
+other cloud credential.
+
+## Cryptographic technology
+
+Concierge implements no cryptography. It relies on the package managers it
+drives:
+
+- `snap` verifies snap assertions and downloads.
+- `apt` verifies archive signatures.
+
+The tools that Concierge installs use cryptography of their own. Juju, for
+example, generates controller certificates during bootstrap.
+
+Concierge doesn't encrypt anything at rest. The confidentiality of the files
+listed in [](#files-concierge-writes) rests on their permissions and on the
+host's own encryption.
+
+> See more:
+>  - [Debian | SecureApt](https://wiki.debian.org/SecureApt)
+>  - [Snap | Security policies](https://snapcraft.io/docs/security-policies)
+
+## Configuring and operating
+
+To harden a machine provisioned by Concierge:
+
+- Provision throwaway machines only, so that a compromised environment can be
+  destroyed rather than cleaned. See [](explanation-prepare-restore-opposites).
+- Review any `concierge.yaml` you didn't write before running it. The
+  `extra-snaps`, `extra-debs`, and `model-defaults` keys all cause privileged
+  actions.
+- Restrict the permissions of any credentials file you pass with
+  `--google-credential-file`. Concierge reads it and doesn't modify it.
+- Harden the installed products themselves. Concierge doesn't harden Juju, LXD,
+  or Kubernetes for you.
+
+Concierge resolves settings from the environment first, then command-line
+flags, then the config file or preset. An environment variable therefore
+overrides a flag, which is the opposite of what you may expect. See
+{ref}`reference-environment-variables`.
+
+The image registry password in a config file expands environment variables, so
+`password: ${REGISTRY_PASSWORD}` reads the value at run time. Prefer that to
+writing the password into the file.
+
+> See also:
+>  - [Juju | Harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/harden-your-juju-deployment/)
+>  - [Canonical K8s | Hardening guide](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/hardening/)
+>  - [LXD | Security](https://documentation.ubuntu.com/lxd/stable-5.21/explanation/security/)
+
+## Logging and monitoring
+
+Concierge writes human-readable progress to standard error, controlled by
+`--verbose` and `--trace`. Separately, it emits structured security events to
+the system journal under the `concierge` identifier, so the audit trail doesn't
+depend on the verbosity you happened to choose.
+
+The events follow the
+[OWASP Application Logging Vocabulary](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Vocabulary_Cheat_Sheet.html):
+
+| Event | Emitted when |
+| :--- | :--- |
+| `sys_startup` | `concierge prepare` begins provisioning |
+| `sys_shutdown` | `concierge restore` begins decommissioning |
+| `authz_admin` | A privileged command runs, or a credentials file is written |
+| `privilege_permissions_changed` | Concierge changes the ownership of a file or directory |
+
+Each event is a JSON object. To read them:
+
+```bash
+journalctl -t concierge -o cat | jq .
+```
+
+Read-only checks are not logged, so the trail covers the actions that changed
+the machine.
+
+The events record the commands Concierge ran. If you pass a secret as an
+argument in `extra-snaps`, `model-defaults`, or a similar key, that argument
+appears in the journal and in `--trace` output. Pass secrets through
+environment variables or a credentials file instead.
+
+## Decommissioning
+
+`concierge restore` kills the Juju controllers it bootstrapped, removes the
+snaps and packages it installed, and deletes `~/.local/share/juju` and
+`~/.kube`.
+
+Two things are left behind, and you should remove them yourself if the machine
+is not being destroyed:
+
+- `~/.cache/concierge/concierge.yaml`, the cached runtime configuration.
+  Concierge reads it during restore and doesn't delete it afterwards. It
+  contains the image registry password if you configured one.
+- Any credentials file you supplied with `--google-credential-file`.
+
+Restore removes what the configuration says `prepare` would have installed, not
+what it observes on the machine. If a snap was already present before you ran
+`prepare`, restore removes it anyway.
+
+To remove Concierge itself, run `sudo snap remove concierge`.
+
+## Security lifecycle
+
+Concierge is distributed as the [`concierge` snap](https://snapcraft.io/concierge)
+and as source releases on GitHub.
+
+Install the snap to get security updates automatically, delivered by snap
+refresh. To schedule or defer refreshes, see the
+[snap documentation](https://snapcraft.io/docs/managing-updates), bearing in
+mind that delaying a refresh delays security fixes.
+
+Security updates are released for all major versions that have had a release in
+the last year, as stated in
+[SECURITY.md](https://github.com/canonical/concierge/blob/main/SECURITY.md). A
+major version with no release for over a year is end of life.
+
+To check which version you are running:
+
+```bash
+concierge version
+```
+
+## Reporting vulnerabilities
+
+To report a security issue, follow the instructions in
+[SECURITY.md](https://github.com/canonical/concierge/blob/main/SECURITY.md).
+
+The preferred channel is a private
+[GitHub security advisory](https://github.com/canonical/concierge/security/advisories/new).
+You can also email `security@ubuntu.com`. To encrypt your email, follow
+[Canonical's reporting instructions](https://ubuntu.com/security/disclosure-policy#contact-us).
+
+Known vulnerabilities are published as
+[GitHub security advisories](https://github.com/canonical/concierge/security/advisories)
+for this repository.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
+describes what you can expect after you report an issue.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -7,18 +7,13 @@ myst:
 (security)=
 # Security
 
-Concierge provisions a machine for charm development. It runs as root, installs
-snaps and Debian packages, bootstraps Juju controllers, and writes credentials
-into the home directory of the user who invoked it.
+Concierge provisions a machine for charm development. It runs as root, installs snaps and Debian packages, bootstraps Juju controllers, and writes credentials into the home directory of the user who invoked it.
 
-Concierge is for throwaway machines: virtual machines, CI runners, and
-dedicated test hosts. Don't run it on your daily workstation. See
-[](explanation-prepare-restore-opposites) for why.
+Concierge is for throwaway machines: virtual machines, CI runners, and dedicated test hosts. Don't run it on your daily workstation. See [](explanation-prepare-restore-opposites) for why.
 
 ## Product architecture
 
-Concierge is a short-lived command, not a daemon. It reads a configuration,
-runs a sequence of privileged commands, and exits.
+Concierge is a short-lived command, not a daemon. It reads a configuration, runs a sequence of privileged commands, and exits.
 
 ```{mermaid}
 flowchart LR
@@ -42,47 +37,28 @@ flowchart LR
 
 Three boundaries matter.
 
-The first is the jump to root. Concierge is invoked with `sudo`, and everything
-it does afterwards runs with full privileges. It executes its steps as shell
-commands, which is deliberate: Concierge is a wrapper around the same commands
-you would otherwise run by hand.
+The first is the jump to root. Concierge is invoked with `sudo`, and everything it does afterwards runs with full privileges. It executes its steps as shell commands, which is deliberate: Concierge is a wrapper around the same commands you would otherwise run by hand.
 
-The second is the configuration. A preset, a config file, environment
-variables, and command-line flags all feed the same plan, and that plan decides
-which commands run as root. Treat a `concierge.yaml` file as you would a
-shell script.
+The second is the configuration. A preset, a config file, environment variables, and command-line flags all feed the same plan, and that plan decides which commands run as root. Treat a `concierge.yaml` file as you would a shell script.
 
-The third is the user's home directory. Concierge writes files there as root
-and then changes their ownership to the invoking user. See
-[](#files-concierge-writes).
+The third is the user's home directory. Concierge writes files there as root and then changes their ownership to the invoking user. See [](#files-concierge-writes).
 
-Concierge opens no listening ports and runs no background process. Once it
-exits, you interact with the tools it installed directly.
+Concierge opens no listening ports and runs no background process. Once it exits, you interact with the tools it installed directly.
 
-Concierge is a classic snap, so snapd doesn't confine it. Classic confinement
-is what lets it manage other snaps, run `apt`, and write outside its own
-directories.
+Concierge is a classic snap, so snapd doesn't confine it. Classic confinement is what lets it manage other snaps, run `apt`, and write outside its own directories.
 
 ## Secure by design
 
-Concierge adds no privileges beyond those needed to install and configure the
-same tools by hand. It implements no cryptography, no authentication, and no
-network service of its own.
+Concierge adds no privileges beyond those needed to install and configure the same tools by hand. It implements no cryptography, no authentication, and no network service of its own.
 
-The tool is declarative, so the set of privileged actions is determined by
-configuration you can read, diff, and commit before it runs. `concierge
-prepare --dry-run` prints what would happen without changing anything.
+The tool is declarative, so the set of privileged actions is determined by configuration you can read, diff, and commit before it runs. `concierge prepare --dry-run` prints what would happen without changing anything.
 
-Credentials are never written to the security event log. When Concierge records
-that it wrote a credentials file, the event carries the path and the number of
-clouds, not the contents.
+Credentials are never written to the security event log. When Concierge records that it wrote a credentials file, the event carries the path and the number of clouds, not the contents.
 
 (files-concierge-writes)=
 ## Files Concierge writes
 
-Concierge writes three files into the home directory of the user it is
-provisioning for. All three can contain secrets, and all three are written
-mode 0600, readable only by that user.
+Concierge writes three files into the home directory of the user it is provisioning for. All three can contain secrets, and all three are written mode 0600, readable only by that user.
 
 | File | Contains |
 | :--- | :--- |
@@ -90,66 +66,41 @@ mode 0600, readable only by that user.
 | `~/.kube/config` | Kubernetes cluster credentials, when a Kubernetes provider is configured |
 | `~/.cache/concierge/concierge.yaml` | The merged runtime configuration, including the image registry password when one is configured |
 
-Concierge also reads a credentials file you provide for the Google provider,
-through `--google-credential-file` or the `google.credentials-file` config key.
-Concierge doesn't change that file's permissions. Store it as you would any
-other cloud credential.
+Concierge also reads a credentials file you provide for the Google provider, through `--google-credential-file` or the `google.credentials-file` config key. Concierge doesn't change that file's permissions. Store it as you would any other cloud credential.
 
 ## Cryptographic technology
 
-Concierge implements no cryptography. It relies on the package managers it
-drives:
+Concierge implements no cryptography. It relies on the package managers it drives:
 
 - `snap` verifies snap assertions and downloads.
 - `apt` verifies archive signatures.
 
-The tools that Concierge installs use cryptography of their own. Juju, for
-example, generates controller certificates during bootstrap.
+The tools that Concierge installs use cryptography of their own. Juju, for example, generates controller certificates during bootstrap.
 
-Concierge doesn't encrypt anything at rest. The confidentiality of the files
-listed in [](#files-concierge-writes) rests on their permissions and on the
-host's own encryption.
+Concierge doesn't encrypt anything at rest. The confidentiality of the files listed in [](#files-concierge-writes) rests on their permissions and on the host's own encryption.
 
-See more: [Debian | SecureApt](https://wiki.debian.org/SecureApt) and
-[Snap | Security policies](https://snapcraft.io/docs/security-policies).
+See more: [Debian | SecureApt](https://wiki.debian.org/SecureApt) and [Snap | Security policies](https://snapcraft.io/docs/security-policies).
 
 ## Configuring and operating
 
 To harden a machine provisioned by Concierge:
 
-- Provision throwaway machines only, so that a compromised environment can be
-  destroyed rather than cleaned. See [](explanation-prepare-restore-opposites).
-- Review any `concierge.yaml` you didn't write before running it. The
-  `extra-snaps`, `extra-debs`, and `model-defaults` keys all cause privileged
-  actions.
-- Restrict the permissions of any credentials file you pass with
-  `--google-credential-file`. Concierge reads it and doesn't modify it.
-- Harden the installed products themselves. Concierge doesn't harden Juju, LXD,
-  or Kubernetes for you.
+- Provision throwaway machines only, so that a compromised environment can be destroyed rather than cleaned. See [](explanation-prepare-restore-opposites).
+- Review any `concierge.yaml` you didn't write before running it. The `extra-snaps`, `extra-debs`, and `model-defaults` keys all cause privileged actions.
+- Restrict the permissions of any credentials file you pass with `--google-credential-file`. Concierge reads it and doesn't modify it.
+- Harden the installed products themselves. Concierge doesn't harden Juju, LXD, or Kubernetes for you.
 
-Concierge resolves settings from the environment first, then command-line
-flags, then the config file or preset. An environment variable therefore
-overrides a flag, which is the opposite of what you may expect. See
-{ref}`reference-environment-variables`.
+Concierge resolves settings from the environment first, then command-line flags, then the config file or preset. An environment variable therefore overrides a flag, which is the opposite of what you may expect. See {ref}`reference-environment-variables`.
 
-The image registry password in a config file expands environment variables, so
-`password: ${REGISTRY_PASSWORD}` reads the value at run time. Prefer that to
-writing the password into the file.
+The image registry password in a config file expands environment variables, so `password: ${REGISTRY_PASSWORD}` reads the value at run time. Prefer that to writing the password into the file.
 
-See also:
-[Juju | Harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/harden-your-juju-deployment/),
-[Canonical K8s | Hardening guide](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/hardening/),
-and [LXD | Security](https://documentation.ubuntu.com/lxd/stable-5.21/explanation/security/).
+See also: [Juju | Harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/harden-your-juju-deployment/), [Canonical K8s | Hardening guide](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/hardening/), and [LXD | Security](https://documentation.ubuntu.com/lxd/stable-5.21/explanation/security/).
 
 ## Logging and monitoring
 
-Concierge writes human-readable progress to standard error, controlled by
-`--verbose` and `--trace`. Separately, it emits structured security events to
-the system journal under the `concierge` identifier, so the audit trail doesn't
-depend on the verbosity you happened to choose.
+Concierge writes human-readable progress to standard error, controlled by `--verbose` and `--trace`. Separately, it emits structured security events to the system journal under the `concierge` identifier, so the audit trail doesn't depend on the verbosity you happened to choose.
 
-The events follow the
-[OWASP Application Logging Vocabulary](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Vocabulary_Cheat_Sheet.html):
+The events follow the [OWASP Application Logging Vocabulary](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Vocabulary_Cheat_Sheet.html):
 
 | Event | Emitted when |
 | :--- | :--- |
@@ -164,48 +115,30 @@ Each event is a JSON object. To read them:
 journalctl -t concierge -o cat | jq .
 ```
 
-Read-only checks are not logged, so the trail covers the actions that changed
-the machine.
+Read-only checks are not logged, so the trail covers the actions that changed the machine.
 
-The events record the commands Concierge ran. If you pass a secret as an
-argument in `extra-snaps`, `model-defaults`, or a similar key, that argument
-appears in the journal and in `--trace` output. Pass secrets through
-environment variables or a credentials file instead.
+The events record the commands Concierge ran. If you pass a secret as an argument in `extra-snaps`, `model-defaults`, or a similar key, that argument appears in the journal and in `--trace` output. Pass secrets through environment variables or a credentials file instead.
 
 ## Decommissioning
 
-`concierge restore` destroys the Juju controllers it bootstrapped, removes the
-snaps and packages it installed, and deletes `~/.local/share/juju` and
-`~/.kube`.
+`concierge restore` destroys the Juju controllers it bootstrapped, removes the snaps and packages it installed, and deletes `~/.local/share/juju` and `~/.kube`.
 
-Two things are left behind, and you should remove them yourself if the machine
-is not being destroyed:
+Two things are left behind, and you should remove them yourself if the machine is not being destroyed:
 
-- `~/.cache/concierge/concierge.yaml`, the cached runtime configuration.
-  Concierge reads it during restore and doesn't delete it afterwards. It
-  contains the image registry password if you configured one.
+- `~/.cache/concierge/concierge.yaml`, the cached runtime configuration. Concierge reads it during restore and doesn't delete it afterwards. It contains the image registry password if you configured one.
 - Any credentials file you supplied with `--google-credential-file`.
 
-Restore removes what the configuration says `prepare` would have installed, not
-what it observes on the machine. If a snap was already present before you ran
-`prepare`, restore removes it anyway.
+Restore removes what the configuration says `prepare` would have installed, not what it observes on the machine. If a snap was already present before you ran `prepare`, restore removes it anyway.
 
 To remove Concierge itself, run `sudo snap remove concierge`.
 
 ## Security lifecycle
 
-Concierge is distributed as the [`concierge` snap](https://snapcraft.io/concierge)
-and as source releases on GitHub.
+Concierge is distributed as the [`concierge` snap](https://snapcraft.io/concierge) and as source releases on GitHub.
 
-Install the snap to get security updates automatically, delivered by snap
-refresh. To schedule or defer refreshes, see the
-[snap documentation](https://snapcraft.io/docs/managing-updates), bearing in
-mind that delaying a refresh delays security fixes.
+Install the snap to get security updates automatically, delivered by snap refresh. To schedule or defer refreshes, see the [snap documentation](https://snapcraft.io/docs/managing-updates), bearing in mind that delaying a refresh delays security fixes.
 
-Security updates are released for all major versions that have had a release in
-the last year, as stated in
-[SECURITY.md](https://github.com/canonical/concierge/blob/main/SECURITY.md). A
-major version with no release for over a year is end of life.
+Security updates are released for all major versions that have had a release in the last year, as stated in [SECURITY.md](https://github.com/canonical/concierge/blob/main/SECURITY.md). A major version with no release for over a year is end of life.
 
 To check which version you are running:
 
@@ -215,17 +148,10 @@ concierge version
 
 ## Reporting vulnerabilities
 
-To report a security issue, follow the instructions in
-[SECURITY.md](https://github.com/canonical/concierge/blob/main/SECURITY.md).
+To report a security issue, follow the instructions in [SECURITY.md](https://github.com/canonical/concierge/blob/main/SECURITY.md).
 
-The preferred channel is a private
-[GitHub security advisory](https://github.com/canonical/concierge/security/advisories/new).
-You can also email `security@ubuntu.com`. To encrypt your email, follow
-[Canonical's reporting instructions](https://ubuntu.com/security/disclosure-policy#contact-us).
+The preferred channel is a private [GitHub security advisory](https://github.com/canonical/concierge/security/advisories/new). You can also email `security@ubuntu.com`. To encrypt your email, follow [Canonical's reporting instructions](https://ubuntu.com/security/disclosure-policy#contact-us).
 
-Known vulnerabilities are published as
-[GitHub security advisories](https://github.com/canonical/concierge/security/advisories)
-for this repository.
+Known vulnerabilities are published as [GitHub security advisories](https://github.com/canonical/concierge/security/advisories) for this repository.
 
-The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
-describes what you can expect after you report an issue.
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) describes what you can expect after you report an issue.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -35,7 +35,7 @@ flowchart LR
     Concierge -->|security events| Journal
 ```
 
-Three boundaries matter.
+Its trust boundaries follow from that position.
 
 The first is the jump to root. Concierge is invoked with `sudo`, and everything it does afterwards runs with full privileges. It executes its steps as shell commands, which is deliberate: Concierge is a wrapper around the same commands you would otherwise run by hand.
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -110,9 +110,8 @@ Concierge doesn't encrypt anything at rest. The confidentiality of the files
 listed in [](#files-concierge-writes) rests on their permissions and on the
 host's own encryption.
 
-> See more:
->  - [Debian | SecureApt](https://wiki.debian.org/SecureApt)
->  - [Snap | Security policies](https://snapcraft.io/docs/security-policies)
+See more: [Debian | SecureApt](https://wiki.debian.org/SecureApt) and
+[Snap | Security policies](https://snapcraft.io/docs/security-policies).
 
 ## Configuring and operating
 
@@ -137,10 +136,10 @@ The image registry password in a config file expands environment variables, so
 `password: ${REGISTRY_PASSWORD}` reads the value at run time. Prefer that to
 writing the password into the file.
 
-> See also:
->  - [Juju | Harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/harden-your-juju-deployment/)
->  - [Canonical K8s | Hardening guide](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/hardening/)
->  - [LXD | Security](https://documentation.ubuntu.com/lxd/stable-5.21/explanation/security/)
+See also:
+[Juju | Harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/harden-your-juju-deployment/),
+[Canonical K8s | Hardening guide](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/hardening/),
+and [LXD | Security](https://documentation.ubuntu.com/lxd/stable-5.21/explanation/security/).
 
 ## Logging and monitoring
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -174,7 +174,7 @@ environment variables or a credentials file instead.
 
 ## Decommissioning
 
-`concierge restore` kills the Juju controllers it bootstrapped, removes the
+`concierge restore` destroys the Juju controllers it bootstrapped, removes the
 snaps and packages it installed, and deletes `~/.local/share/juju` and
 `~/.kube`.
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -59,6 +59,10 @@ and then changes their ownership to the invoking user. See
 Concierge opens no listening ports and runs no background process. Once it
 exits, you interact with the tools it installed directly.
 
+Concierge is a classic snap, so snapd doesn't confine it. Classic confinement
+is what lets it manage other snaps, run `apt`, and write outside its own
+directories.
+
 ## Secure by design
 
 Concierge adds no privileges beyond those needed to install and configure the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,7 @@ sphinx-notfound-page~=1.1
 sphinx-reredirects==0.1.6
 sphinx-tabs~=3.5
 sphinxcontrib-jquery~=4.1
+sphinxcontrib-mermaid~=1.0
 sphinxext-opengraph~=0.13
 sphinx-rerediraffe>=0.0.3, <1.0.0
 


### PR DESCRIPTION
`docs/explanation/security.md` said how to report a vulnerability and that the rest would follow. This is the rest.

The security page covers the seven sections the security-documentation standard asks for: the trust boundaries and where root enters the picture, what Concierge delegates cryptography to, the three files it writes and what is in them, how to harden and operate a machine it provisioned, the OWASP events it writes to the journal, what `restore` does and does not remove, and how updates are delivered and verified.

* The `## Files Concierge writes` section says those three files are written `0600`, which is #263. Until that merges the page is ahead of the code by one PR.
* Two flaws the page is honest about: a secret passed as a command argument reaches both the journal and `--trace` output, and `restore` leaves `~/.cache/concierge/concierge.yaml` behind with the registry password in it.
* `SECURITY.md` keeps supported versions and how to report a vulnerability, and points at the page for the rest. Its Cryptography, Hardening, Risks, Good practice and Security logging sections duplicated the page, and its Hardening section said no additional steps were required and then recommended some.

[Preview](https://canonical-juju-concierge--262.com.readthedocs.build/explanation/security/).
