### PR TITLE
fix: write files in the user's home directory as 0600

### DIFF
--- a/internal/system/helpers.go
+++ b/internal/system/helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -75,6 +74,13 @@ func ReadHomeDirFile(w Worker, filePath string) ([]byte, error) {
 
 // WriteHomeDirFile writes contents to a path relative to the real user's home directory,
 // creating parent directories and adjusting ownership as needed.
+//
+// Files are written 0600, so they are readable only by the user concierge is
+// provisioning for. Every caller writes a file that can carry secrets: Juju
+// cloud credentials, a kubeconfig, and the cached runtime config (which holds
+// the image registry password when one is configured). Juju and k8s both keep
+// their own copies of these at 0600, so writing them wider would relax the
+// permissions on material those tools already treat as sensitive.
 func WriteHomeDirFile(w Worker, filePath string, contents []byte) error {
 	dir := path.Dir(filePath)
 
@@ -85,7 +91,7 @@ func WriteHomeDirFile(w Worker, filePath string, contents []byte) error {
 
 	absPath := path.Join(w.User().HomeDir, filePath)
 
-	if err := w.WriteFile(absPath, contents, 0644); err != nil {
+	if err := w.WriteFile(absPath, contents, 0600); err != nil {
 		return fmt.Errorf("failed to write file '%s': %w", absPath, err)
 	}
 
@@ -107,7 +113,10 @@ func MkHomeSubdirectory(w Worker, subdirectory string) error {
 	user := w.User()
 	dir := path.Join(user.HomeDir, subdirectory)
 
-	err := w.MkdirAll(dir, os.ModePerm)
+	// 0755 rather than os.ModePerm: concierge runs as root, and relying on the
+	// umask to reduce 0777 would leave a world-writable directory wherever the
+	// umask is permissive.
+	err := w.MkdirAll(dir, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create directory '%s': %w", dir, err)
 	}

--- a/internal/system/helpers.go
+++ b/internal/system/helpers.go
@@ -113,9 +113,7 @@ func MkHomeSubdirectory(w Worker, subdirectory string) error {
 	user := w.User()
 	dir := path.Join(user.HomeDir, subdirectory)
 
-	// 0755 rather than os.ModePerm: concierge runs as root, and relying on the
-	// umask to reduce 0777 would leave a world-writable directory wherever the
-	// umask is permissive.
+	// 0755 rather than os.ModePerm so permissions don't depend on umask.
 	err := w.MkdirAll(dir, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create directory '%s': %w", dir, err)

--- a/internal/system/helpers_test.go
+++ b/internal/system/helpers_test.go
@@ -1,0 +1,101 @@
+package system
+
+import (
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+// setUmask sets the process umask and returns the previous value, so that a test
+// can check the mode that concierge asks for rather than the mode the ambient
+// umask happens to allow.
+func setUmask(t *testing.T, mask int) int {
+	t.Helper()
+	return syscall.Umask(mask)
+}
+
+// realFileSystem is a Worker that writes to a real filesystem, so that tests can
+// assert on the permissions that end up on disk. The MockSystem discards the
+// mode it is given, which is exactly the detail these tests are about.
+type realFileSystem struct {
+	*MockSystem
+	user *user.User
+}
+
+func (r *realFileSystem) User() *user.User { return r.user }
+
+func (r *realFileSystem) WriteFile(filePath string, contents []byte, perm os.FileMode) error {
+	return os.WriteFile(filePath, contents, perm)
+}
+
+func (r *realFileSystem) MkdirAll(dirPath string, perm os.FileMode) error {
+	return os.MkdirAll(dirPath, perm)
+}
+
+// ChownAll is a no-op: the test user already owns the temporary directory, and
+// changing ownership needs privileges the test doesn't have.
+func (r *realFileSystem) ChownAll(string, *user.User) error { return nil }
+
+func newRealFileSystem(t *testing.T) *realFileSystem {
+	t.Helper()
+	return &realFileSystem{
+		MockSystem: NewMockSystem(),
+		user: &user.User{
+			HomeDir:  t.TempDir(),
+			Uid:      strconv.Itoa(os.Getuid()),
+			Gid:      strconv.Itoa(os.Getgid()),
+			Username: "test",
+		},
+	}
+}
+
+// TestWriteHomeDirFilePermissions checks that files written into the user's home
+// directory are readable only by that user. Every caller of WriteHomeDirFile
+// writes a file that can carry secrets, so a wider mode would expose Juju cloud
+// credentials, a kubeconfig, or a registry password to other local users.
+func TestWriteHomeDirFilePermissions(t *testing.T) {
+	w := newRealFileSystem(t)
+
+	err := WriteHomeDirFile(w, path.Join(".local", "share", "juju", "credentials.yaml"), []byte("credentials: {}\n"))
+	if err != nil {
+		t.Fatalf("WriteHomeDirFile returned an error: %v", err)
+	}
+
+	written := path.Join(w.User().HomeDir, ".local", "share", "juju", "credentials.yaml")
+	info, err := os.Stat(written)
+	if err != nil {
+		t.Fatalf("stat of the written file failed: %v", err)
+	}
+
+	if got, want := info.Mode().Perm(), os.FileMode(0600); got != want {
+		t.Errorf("file mode is %#o, want %#o", got, want)
+	}
+}
+
+// TestMkHomeSubdirectoryPermissions checks that the directories created along the
+// way are not group- or world-writable. The mode is set explicitly rather than
+// left to the umask, because concierge runs as root and a permissive umask would
+// otherwise produce a world-writable directory.
+func TestMkHomeSubdirectoryPermissions(t *testing.T) {
+	umask := setUmask(t, 0)
+	defer setUmask(t, umask)
+
+	w := newRealFileSystem(t)
+
+	if err := MkHomeSubdirectory(w, path.Join(".local", "share", "juju")); err != nil {
+		t.Fatalf("MkHomeSubdirectory returned an error: %v", err)
+	}
+
+	for _, dir := range []string{".local", path.Join(".local", "share"), path.Join(".local", "share", "juju")} {
+		info, err := os.Stat(path.Join(w.User().HomeDir, dir))
+		if err != nil {
+			t.Fatalf("stat of %q failed: %v", dir, err)
+		}
+		if got, want := info.Mode().Perm(), os.FileMode(0755); got != want {
+			t.Errorf("mode of %q is %#o, want %#o", dir, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Concierge writes three things into the home directory of the user it is provisioning for, and all of them can carry secrets: Juju cloud credentials, a kubeconfig, and the cached runtime configuration, which holds the image registry password when one is configured. All three were written `0644`, so any other local user could read them.

Juju and Kubernetes both keep their own copies of that material at `0600` (`~/.local/share/juju/*.yaml` and `/etc/kubernetes/admin.conf`), so Concierge was relaxing the permissions on files those tools already treat as sensitive.

`MkHomeSubdirectory` also asked for `os.ModePerm`, which is `0777` before the umask is applied. With the usual `022` umask that gives `0755`, which is what we want, but the mode shouldn't depend on the umask when the process is running as root. It now asks for `0755` directly.

Verified against Juju 4.0.14 and a live Kubernetes cluster that neither tool needs the wider permissions: `juju credentials` reads a `0600` credentials.yaml, and `kubectl` works against a `0600` kubeconfig.