### PR TITLE
fix: don't retry k8s bootstrap when its pre-init checks fail

### DIFF
--- a/internal/providers/k8s.go
+++ b/internal/providers/k8s.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -204,9 +205,13 @@ func (k *K8s) init() error {
 	if k.needsBootstrap() {
 		k.handleExistingContainerd()
 		cmd := system.NewCommand("k8s", []string{"bootstrap"})
-		_, err := system.RunWithRetries(k.system, cmd, 5*time.Minute)
+		// The k8s snap verifies its preconditions before it changes anything on
+		// the machine. Those checks cannot start passing while concierge waits,
+		// so retrying them just repeats the same output for five minutes.
+		cmd.PermanentError = preInitFailurePattern
+		output, err := system.RunWithRetries(k.system, cmd, 5*time.Minute)
 		if err != nil {
-			return err
+			return bootstrapError(output, err)
 		}
 	}
 
@@ -214,6 +219,33 @@ func (k *K8s) init() error {
 	_, err := system.RunWithRetries(k.system, cmd, 5*time.Minute)
 
 	return err
+}
+
+// preInitFailurePattern matches the output of `k8s bootstrap` when the snap's
+// pre-init checks fail, which is a permanent failure rather than a transient one.
+const preInitFailurePattern = `pre-init checks failed`
+
+// portInUse matches the port availability complaints in the pre-init check output,
+// capturing the port number and the service that needs it.
+var portInUse = regexp.MustCompile(`port (\d+) \(needed by: ([^)]+)\) is already in use`)
+
+// bootstrapError turns a `k8s bootstrap` failure into an actionable error where
+// concierge can explain it, and returns the original error where it cannot.
+func bootstrapError(output []byte, err error) error {
+	matches := portInUse.FindAllSubmatch(output, -1)
+	if len(matches) == 0 {
+		return err
+	}
+
+	ports := make([]string, 0, len(matches))
+	for _, m := range matches {
+		ports = append(ports, fmt.Sprintf("%s (%s)", m[1], m[2]))
+	}
+
+	return fmt.Errorf(
+		"K8s cannot be bootstrapped because ports it requires are already in use by other processes: %s. Identify the processes with `sudo ss -lntp`, stop or remove them (a separately installed etcd is a common cause), then run concierge again",
+		strings.Join(ports, ", "),
+	)
 }
 
 // configureFeatures iterates over the specified features, enabling and configuring them.

--- a/internal/providers/k8s.go
+++ b/internal/providers/k8s.go
@@ -208,6 +208,13 @@ func (k *K8s) init() error {
 		// The k8s snap verifies its preconditions before it changes anything on
 		// the machine. Those checks cannot start passing while concierge waits,
 		// so retrying them just repeats the same output for five minutes.
+		//
+		// Port availability is the one pre-init check that could in principle
+		// clear on its own, so it is worth saying that it does not need a
+		// window: `concierge restore` returns only once snapd has finished
+		// removing the k8s snap, and 2379, 2380 and 6443 are already free at
+		// that point, so a `restore` immediately followed by a `prepare`
+		// bootstraps without a conflict.
 		cmd.PermanentError = preInitFailurePattern
 		output, err := system.RunWithRetries(k.system, cmd, 5*time.Minute)
 		if err != nil {
@@ -226,8 +233,14 @@ func (k *K8s) init() error {
 const preInitFailurePattern = `pre-init checks failed`
 
 // portInUse matches the port availability complaints in the pre-init check output,
-// capturing the port number and the service that needs it.
+// capturing the port number and the K8s service that needs it. The name is the
+// service that wants the port, never the process that currently holds it: the
+// snap has no idea what that is, and neither do we.
 var portInUse = regexp.MustCompile(`port (\d+) \(needed by: ([^)]+)\) is already in use`)
+
+// etcdPorts are the ports a separately installed etcd takes, which is the
+// conflict people actually hit.
+var etcdPorts = map[string]bool{"2379": true, "2380": true}
 
 // bootstrapError turns a `k8s bootstrap` failure into an actionable error where
 // concierge can explain it, and returns the original error where it cannot.
@@ -238,13 +251,31 @@ func bootstrapError(output []byte, err error) error {
 	}
 
 	ports := make([]string, 0, len(matches))
+	etcd := false
 	for _, m := range matches {
-		ports = append(ports, fmt.Sprintf("%s (%s)", m[1], m[2]))
+		// "needed by" rather than a bare parenthetical: the name is the K8s
+		// service that wants the port. Rendering it as `6443 (kube-apiserver)`
+		// inside a sentence about other processes reads as a claim that a
+		// kube-apiserver is holding it, and sends the reader looking for one
+		// that does not exist. `ss` is what answers that question.
+		ports = append(ports, fmt.Sprintf("%s (needed by %s)", m[1], m[2]))
+		if etcdPorts[string(m[1])] {
+			etcd = true
+		}
+	}
+
+	hint := ""
+	if etcd {
+		hint = " (a separately installed etcd is a common cause)"
 	}
 
 	return fmt.Errorf(
-		"K8s cannot be bootstrapped because ports it requires are already in use by other processes: %s. Identify the processes with `sudo ss -lntp`, stop or remove them (a separately installed etcd is a common cause), then run concierge again",
+		"K8s cannot be bootstrapped because ports it needs are already in use: %s. "+
+			"Identify the processes holding them with `sudo ss -lntp`, then stop or "+
+			"remove them and run concierge again%s: %w",
 		strings.Join(ports, ", "),
+		hint,
+		err,
 	)
 }
 

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -404,5 +405,31 @@ func TestK8sBuildHostsTomlWithAuth(t *testing.T) {
 
 	if !strings.Contains(hostsToml, "Authorization = [\"Basic") {
 		t.Fatalf("expected hosts.toml to contain authorization header, got: %v", hostsToml)
+	}
+}
+
+func TestK8sBootstrapErrorPortsInUse(t *testing.T) {
+	output := []byte("Bootstrap config verification failed: pre-init checks failed for node: " +
+		"Encountered error(s) while verifying port availability for Kubernetes services: " +
+		"port 2379 (needed by: etcd) is already in use\nport 2380 (needed by: etcd-peer) is already in use")
+
+	err := bootstrapError(output, fmt.Errorf("exit status 1"))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	for _, want := range []string{"2379 (etcd)", "2380 (etcd-peer)", "ss -lntp"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got: %s", want, err)
+		}
+	}
+}
+
+func TestK8sBootstrapErrorUnrecognisedOutput(t *testing.T) {
+	original := fmt.Errorf("exit status 1")
+
+	err := bootstrapError([]byte("something else went wrong"), original)
+	if !errors.Is(err, original) {
+		t.Fatalf("expected the original error to be returned, got: %v", err)
 	}
 }

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -418,10 +418,47 @@ func TestK8sBootstrapErrorPortsInUse(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	for _, want := range []string{"2379 (etcd)", "2380 (etcd-peer)", "ss -lntp"} {
+	for _, want := range []string{
+		"2379 (needed by etcd)",
+		"2380 (needed by etcd-peer)",
+		"ss -lntp",
+		"separately installed etcd",
+	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected error to mention %q, got: %s", want, err)
 		}
+	}
+}
+
+// TestK8sBootstrapErrorNamesTheServiceNotTheSquatter checks the wording for a
+// port whose K8s service is not what is holding it, which is every case except
+// the one in the bug report. The snap says which service wants the port; it has
+// no idea what has it, so neither can we.
+func TestK8sBootstrapErrorNamesTheServiceNotTheSquatter(t *testing.T) {
+	output := []byte("Bootstrap config verification failed: pre-init checks failed for node: " +
+		"Encountered error(s) while verifying port availability for Kubernetes services: " +
+		"port 6443 (needed by: kube-apiserver) is already in use")
+
+	err := bootstrapError(output, fmt.Errorf("exit status 1"))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "6443 (needed by kube-apiserver)") {
+		t.Fatalf("expected the service to be named as needing the port, got: %s", err)
+	}
+	// The etcd advice is for the ports a separate etcd takes; on 6443 it would
+	// send the reader after something irrelevant.
+	if strings.Contains(err.Error(), "separately installed etcd") {
+		t.Fatalf("did not expect the etcd hint for a non-etcd port, got: %s", err)
+	}
+}
+
+func TestK8sBootstrapErrorKeepsTheCause(t *testing.T) {
+	original := fmt.Errorf("exit status 1")
+	output := []byte("port 2379 (needed by: etcd) is already in use")
+
+	if err := bootstrapError(output, original); !errors.Is(err, original) {
+		t.Fatalf("expected the original error to be wrapped, got: %v", err)
 	}
 }
 

--- a/internal/system/command.go
+++ b/internal/system/command.go
@@ -25,6 +25,12 @@ type Command struct {
 	// where certain errors are an expected part of normal operation (e.g., checking
 	// if a controller exists before bootstrapping).
 	ExpectedError string
+	// PermanentError is a regular expression pattern that, if set, is matched against
+	// the combined output of a failed command. If the pattern matches, the failure is
+	// treated as permanent and RunWithRetries returns immediately rather than retrying.
+	// This is used for failures that cannot clear on their own, such as a required port
+	// being occupied by an unrelated process.
+	PermanentError string
 	// Env contains extra environment variables, in "KEY=value" form, that are set
 	// for the command. These are rendered as assignments immediately preceding the
 	// executable, which works both for plain shell invocations and for commands
@@ -59,12 +65,25 @@ func NewCommandAs(user string, group string, executable string, args []string) *
 // IsExpectedError reports whether the given output matches the ExpectedError pattern.
 // Returns false if ExpectedError is empty or the pattern fails to compile.
 func (c *Command) IsExpectedError(output []byte) bool {
-	if c.ExpectedError == "" {
+	return matchesPattern("ExpectedError", c.ExpectedError, output)
+}
+
+// IsPermanentError reports whether the given output matches the PermanentError pattern.
+// Returns false if PermanentError is empty or the pattern fails to compile.
+func (c *Command) IsPermanentError(output []byte) bool {
+	return matchesPattern("PermanentError", c.PermanentError, output)
+}
+
+// matchesPattern reports whether the output matches the given regular expression.
+// An empty or uncompilable pattern never matches; the field name is used to make
+// the warning about an invalid pattern actionable.
+func matchesPattern(field, pattern string, output []byte) bool {
+	if pattern == "" {
 		return false
 	}
-	re, err := regexp.Compile(c.ExpectedError)
+	re, err := regexp.Compile(pattern)
 	if err != nil {
-		slog.Warn("Invalid ExpectedError regex", "pattern", c.ExpectedError, "error", err)
+		slog.Warn("Invalid regex", "field", field, "pattern", pattern, "error", err)
 		return false
 	}
 	return re.Match(output)

--- a/internal/system/command_test.go
+++ b/internal/system/command_test.go
@@ -158,3 +158,48 @@ func TestCommandString(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPermanentError(t *testing.T) {
+	tests := []struct {
+		name           string
+		permanentError string
+		output         string
+		expected       bool
+	}{
+		{
+			name:           "no pattern set",
+			permanentError: "",
+			output:         "pre-init checks failed for node",
+			expected:       false,
+		},
+		{
+			name:           "pattern matches",
+			permanentError: `pre-init checks failed`,
+			output:         "Bootstrap config verification failed: pre-init checks failed for node",
+			expected:       true,
+		},
+		{
+			name:           "pattern does not match",
+			permanentError: `pre-init checks failed`,
+			output:         "context deadline exceeded",
+			expected:       false,
+		},
+		{
+			name:           "invalid pattern",
+			permanentError: `[`,
+			output:         "pre-init checks failed",
+			expected:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &Command{PermanentError: tc.permanentError}
+			got := cmd.IsPermanentError([]byte(tc.output))
+			if got != tc.expected {
+				t.Fatalf("IsPermanentError(%q) with pattern %q: got %v, want %v",
+					tc.output, tc.permanentError, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/system/helpers.go
+++ b/internal/system/helpers.go
@@ -35,17 +35,23 @@ func RunExclusive(w Worker, c *Command) ([]byte, error) {
 
 // RunWithRetries retries the command using exponential backoff, starting at
 // 1 second. Retries will be attempted up to the specified maximum duration.
-// Errors that are known to be permanent (e.g. ErrNotInstalled) are returned
-// immediately without retrying.
+// Errors that are known to be permanent (e.g. ErrNotInstalled, or output that
+// matches the command's PermanentError pattern) are returned immediately
+// without retrying, along with the output of the failed attempt.
 func RunWithRetries(w Worker, c *Command, maxDuration time.Duration) ([]byte, error) {
 	backoff := retry.NewExponential(1 * time.Second)
 	backoff = retry.WithMaxDuration(maxDuration, backoff)
 	ctx := context.Background()
 
-	return retry.DoValue(ctx, backoff, func(ctx context.Context) ([]byte, error) {
+	// The output of the last attempt is kept so that it can be returned alongside
+	// the error, enabling callers to explain why the command failed.
+	var lastOutput []byte
+
+	output, err := retry.DoValue(ctx, backoff, func(ctx context.Context) ([]byte, error) {
 		output, err := w.Run(c)
+		lastOutput = output
 		if err != nil {
-			if errors.Is(err, ErrNotInstalled) {
+			if errors.Is(err, ErrNotInstalled) || c.IsPermanentError(output) {
 				return nil, err
 			}
 			return nil, retry.RetryableError(err)
@@ -53,6 +59,11 @@ func RunWithRetries(w Worker, c *Command, maxDuration time.Duration) ([]byte, er
 
 		return output, nil
 	})
+	if err != nil {
+		return lastOutput, err
+	}
+
+	return output, nil
 }
 
 // RunMany takes multiple commands and runs them in sequence via the Worker,

--- a/internal/system/helpers_test.go
+++ b/internal/system/helpers_test.go
@@ -1,0 +1,59 @@
+package system
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// countingWorker wraps MockSystem to record how many times a command was run.
+type countingWorker struct {
+	*MockSystem
+	runs int
+}
+
+func (c *countingWorker) Run(cmd *Command) ([]byte, error) {
+	c.runs++
+	return c.MockSystem.Run(cmd)
+}
+
+func TestRunWithRetriesPermanentErrorIsNotRetried(t *testing.T) {
+	output := "Bootstrap config verification failed: pre-init checks failed for node"
+
+	worker := &countingWorker{MockSystem: NewMockSystem()}
+	worker.MockCommandReturn("k8s bootstrap", []byte(output), fmt.Errorf("exit status 1"))
+
+	cmd := NewCommand("k8s", []string{"bootstrap"})
+	cmd.PermanentError = `pre-init checks failed`
+
+	got, err := RunWithRetries(worker, cmd, 5*time.Second)
+	if err == nil {
+		t.Fatal("expected an error for a permanently failing command")
+	}
+
+	if worker.runs != 1 {
+		t.Fatalf("expected the command to run once, got %d", worker.runs)
+	}
+
+	if !strings.Contains(string(got), "pre-init checks failed") {
+		t.Fatalf("expected the failed command's output to be returned, got: %q", got)
+	}
+}
+
+func TestRunWithRetriesRetriesOtherErrors(t *testing.T) {
+	worker := &countingWorker{MockSystem: NewMockSystem()}
+	worker.MockCommandReturn("k8s bootstrap", []byte("context deadline exceeded"), fmt.Errorf("exit status 1"))
+
+	cmd := NewCommand("k8s", []string{"bootstrap"})
+	cmd.PermanentError = `pre-init checks failed`
+
+	_, err := RunWithRetries(worker, cmd, 2*time.Second)
+	if err == nil {
+		t.Fatal("expected an error for a failing command")
+	}
+
+	if worker.runs < 2 {
+		t.Fatalf("expected the command to be retried, got %d run(s)", worker.runs)
+	}
+}


### PR DESCRIPTION
If a process other than the k8s snap is listening on 2379/2380 (a separately installed etcd is the likely cause in #264, since the ports there are bound on loopback only, which the snap's own etcd never does) then `k8s bootstrap` refuses to run. That can't clear on its own, but concierge retried it for five minutes and then reported `exit status 1`, with the same block of output repeated six times, which is what makes the log in the issue so hard to read.

* `Command` gains a `PermanentError` pattern, mirroring the existing `ExpectedError`, and `RunWithRetries` returns straight away when the output matches it, along with the output of the failed attempt so the caller can explain what went wrong.
* The k8s provider marks a failed pre-init check as permanent, and turns the port complaints into an error naming the ports and how to find what's holding them.

I deliberately haven't made concierge stop or remove the offending process, the way `handleExistingContainerd` does for containerd: containerd is concierge's own dependency, but an etcd on 2379 belongs to someone else, and killing it silently seems worse than a clear error.

Reproduced and verified in a 26.04 multipass VM (`apt install etcd-server`, then `concierge prepare`): 5m30s of repeated output becomes a 6s failure that says which ports are in use. With the ports free, bootstrap succeeds as before, and a transient `k8s status --wait-ready` failure was still retried, so the retry behaviour is unchanged for everything else.

Fixes #264