### PR TITLE
fix: pin MicroK8s to a channel that starts on current kernels

### DIFF
--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -14,7 +14,13 @@ import (
 
 // Default channel from which MicroK8s is installed when the latest strict
 // version cannot be determined.
-const defaultMicroK8sChannel = "1.32-strict/stable"
+//
+// Do not move this below 1.34. On a kernel with AppArmor network_v9
+// mediation, strict channels up to and including 1.33 cannot load their
+// containerd profile ("apparmor_parser: Unable to replace
+// cri-containerd.apparmor.d. Profile doesn't conform to protocol"), so
+// containerd never starts and every workload behind it crashloops.
+const defaultMicroK8sChannel = "1.36-strict/stable"
 
 // NewMicroK8s constructs a new MicroK8s provider instance.
 func NewMicroK8s(r system.Worker, config *config.Config) *MicroK8s {

--- a/tests/microk8s-image-registry/concierge.yaml
+++ b/tests/microk8s-image-registry/concierge.yaml
@@ -2,7 +2,7 @@ providers:
   microk8s:
     enable: true
     bootstrap: false
-    channel: 1.31-strict/stable
+    channel: 1.32-strict/stable
     addons:
       - dns
     image-registry:

--- a/tests/microk8s-image-registry/concierge.yaml
+++ b/tests/microk8s-image-registry/concierge.yaml
@@ -2,7 +2,7 @@ providers:
   microk8s:
     enable: true
     bootstrap: false
-    channel: 1.34-strict/stable
+    channel: 1.36-strict/stable
     addons:
       - dns
     image-registry:

--- a/tests/microk8s-image-registry/concierge.yaml
+++ b/tests/microk8s-image-registry/concierge.yaml
@@ -2,7 +2,7 @@ providers:
   microk8s:
     enable: true
     bootstrap: false
-    channel: 1.32-strict/stable
+    channel: 1.34-strict/stable
     addons:
       - dns
     image-registry:

--- a/tests/provider-microk8s/concierge.yaml
+++ b/tests/provider-microk8s/concierge.yaml
@@ -2,7 +2,7 @@ providers:
   microk8s:
     enable: true
     bootstrap: true
-    channel: 1.31-strict/stable
+    channel: 1.32-strict/stable
     addons:
       - hostpath-storage
       - dns

--- a/tests/provider-microk8s/concierge.yaml
+++ b/tests/provider-microk8s/concierge.yaml
@@ -2,7 +2,7 @@ providers:
   microk8s:
     enable: true
     bootstrap: true
-    channel: 1.34-strict/stable
+    channel: 1.36-strict/stable
     addons:
       - hostpath-storage
       - dns

--- a/tests/provider-microk8s/concierge.yaml
+++ b/tests/provider-microk8s/concierge.yaml
@@ -2,7 +2,7 @@ providers:
   microk8s:
     enable: true
     bootstrap: true
-    channel: 1.32-strict/stable
+    channel: 1.34-strict/stable
     addons:
       - hostpath-storage
       - dns

--- a/tests/provider-microk8s/task.yaml
+++ b/tests/provider-microk8s/task.yaml
@@ -19,7 +19,7 @@ execute: |
 
   list="$(snap list microk8s)"
   echo $list | MATCH microk8s
-  echo $list | MATCH 1.31-strict/stable
+  echo $list | MATCH 1.32-strict/stable
 
   list="$(snap list)"
   echo $list | MATCH juju

--- a/tests/provider-microk8s/task.yaml
+++ b/tests/provider-microk8s/task.yaml
@@ -15,7 +15,7 @@ execute: |
 
   list="$(snap list microk8s)"
   echo $list | MATCH microk8s
-  echo $list | MATCH 1.34-strict/stable
+  echo $list | MATCH 1.36-strict/stable
 
   list="$(snap list)"
   echo $list | MATCH juju

--- a/tests/provider-microk8s/task.yaml
+++ b/tests/provider-microk8s/task.yaml
@@ -5,17 +5,11 @@ systems:
 execute: |
   pushd "${SPREAD_PATH}/${SPREAD_TASK}"
 
-  # Known upstream issue: https://github.com/canonical/microk8s/issues/5394
-  # This test should be fast, so timing out indicates that we're hanging.
-  # `timeout` exits with 124 if the command times out.
-  rc=0
-  timeout 10m "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq" || rc=$?
-  if [ $rc -eq 124 ]; then
-    echo "EXPECTED FAILURE: concierge prepare timed out (known upstream microk8s issue)"
-    exit 0
-  fi
-  echo "Concierge prepare completed with exit code $rc when we expected it to timeout!"
-  exit 1
+  # This test should be fast, so timing out means we are hanging. That used to
+  # be the expected outcome, because of the AppArmor denial behind
+  # https://github.com/canonical/microk8s/issues/5394, which the channel bump
+  # in concierge.yaml avoids.
+  timeout 10m "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
 
   list="$(snap list microk8s)"
   echo $list | MATCH microk8s

--- a/tests/provider-microk8s/task.yaml
+++ b/tests/provider-microk8s/task.yaml
@@ -6,14 +6,16 @@ execute: |
   pushd "${SPREAD_PATH}/${SPREAD_TASK}"
 
   # This test should be fast, so timing out means we are hanging. That used to
-  # be the expected outcome, because of the AppArmor denial behind
-  # https://github.com/canonical/microk8s/issues/5394, which the channel bump
-  # in concierge.yaml avoids.
+  # be the expected outcome: on a kernel with AppArmor network_v9 mediation,
+  # MicroK8s strict up to and including 1.33 cannot load its containerd
+  # profile at all ("apparmor_parser: Unable to replace
+  # cri-containerd.apparmor.d. Profile doesn't conform to protocol"), so
+  # containerd never starts. The channel bump in concierge.yaml avoids it.
   timeout 10m "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
 
   list="$(snap list microk8s)"
   echo $list | MATCH microk8s
-  echo $list | MATCH 1.32-strict/stable
+  echo $list | MATCH 1.34-strict/stable
 
   list="$(snap list)"
   echo $list | MATCH juju


### PR DESCRIPTION
On a kernel with AppArmor `network_v9` mediation, MicroK8s strict up to and including 1.33 can't load its containerd profile at all:

```
+ apparmor_parser -r /snap/microk8s/8798/containerd-profile
apparmor_parser: Unable to replace "cri-containerd.apparmor.d".  Profile doesn't conform to protocol
```

`daemon-containerd` then restarts five times and gives up, so containerd never runs and everything behind it crashloops. That's a different mechanism from the one in the issue: nothing is denied, because there's nothing running to deny.

* Both test pins and `defaultMicroK8sChannel` move to `1.36-strict/stable`. The default matters more than the pins: anyone taking it on a 7.x kernel got a cluster that couldn't run a workload. MicroK8s has no LTS track, so there's nothing to prefer an older channel for.
* `tests/provider-microk8s` no longer asserts that `concierge prepare` times out. That guard exits 0 on a timeout and 1 on success, so it can't survive this being fixed, and everything after it (including the channel assertion) was unreachable. It also can't tell the bug from a slow snap download, which is how it passed for me on the first attempt.
* `tests/microk8s-image-registry` had the same pin and no guard at all, so it was one addon away from the same hang.

* The other `1.3x` pins in the tree - `tests/provider-k8s`, `tests/k8s-*`, `tests/status-failed` on `1.32-classic/stable` - stay put. That is the `k8s` snap rather than microk8s, so after this there are two different "1.3x" pins in the tree meaning two different things.

Verified in multipass: on 26.04 with kernel 7.0.0-30, `daemon-containerd` reaches `active` on 1.34 and 1.36 but not on 1.31, 1.32 or 1.33, and on 1.36 `concierge prepare` exits 0 with every assertion in the task holding. On 24.04 with kernel 6.8.0-138, which has `network_v8` and no v9, even 1.31 is completely healthy, so the trigger is the mediation generation rather than the MicroK8s version on its own.

One thing the green CI on this branch does not prove: spread runs on the `github-ci` backend, so these tasks execute on the GitHub runner, which is 24.04 with `network_v8`. `tests/microk8s-image-registry` was pulling images through containerd on strict 1.31 there quite happily, so whatever made `tests/provider-microk8s` hang on the runner was not the profile bug - a slow snap download is the likeliest candidate, which is the other thing the old guard could not distinguish. The bump is still right, the AppArmor failure is still real on a v9 kernel, but the next timeout on that task wants diagnosing rather than attributing to #5394.

Fixes #253
